### PR TITLE
Replaced interface address by ARP source address for pcap filter

### DIFF
--- a/arp-scan.c
+++ b/arp-scan.c
@@ -267,7 +267,7 @@ main(int argc, char *argv[]) {
          }
       }
 /*
- *	The filter string selects packets addressed to our interface address
+ *	The filter string selects packets addressed to the ARP source address
  *	that are Ethernet-II ARP packets, 802.3 LLC/SNAP ARP packets,
  *	802.1Q tagged ARP packets or 802.1Q tagged 802.3 LLC/SNAP ARP packets.
  */
@@ -278,9 +278,9 @@ main(int argc, char *argv[]) {
                                  "(ether[12:2]=0x8100 and "
                                  "ether[18:4]=0xaaaa0300 and "
                                  "ether[24:2]=0x0806))",
-                                 interface_mac[0], interface_mac[1],
-                                 interface_mac[2], interface_mac[3],
-                                 interface_mac[4], interface_mac[5]);
+                                 arp_sha[0], arp_sha[1],
+                                 arp_sha[2], arp_sha[3],
+                                 arp_sha[4], arp_sha[5]);
       if (verbose > 1)
          warn_msg("DEBUG: pcap filter string: \"%s\"", filter_string);
       if ((pcap_compile(pcap_handle, &filter, filter_string, OPTIMISE,

--- a/arp-scan.h
+++ b/arp-scan.h
@@ -136,7 +136,7 @@
 #define DEFAULT_RETRY 2                 /* Default number of retries */
 #define DEFAULT_TIMEOUT 500             /* Default per-host timeout in ms */
 #define SNAPLEN 64			/* 14 (ether) + 28 (ARP) + extra */
-#define PROMISC 0			/* Enable promiscuous mode */
+#define PROMISC 1			/* Enable promiscuous mode */
 #define TO_MS 0				/* Timeout for pcap_open_live() */
 #define OPTIMISE 1			/* Optimise pcap filter */
 #define ARPHRD_ETHER 1			/* Ethernet ARP type */


### PR DESCRIPTION
Hi, 
I think it fulfills this TODO in your wiki:

> Use source_mac rather than interface_mac in the pcap filter, as suggested by Justin Keogh. This will
> allow arp-scan to receive packets with spoofed MAC source addresses. 

arp_sha contains the value if interface_mac if not set, which is what is expected. I do not see any side effect.
Cheers,
Cedric