### PR TITLE
replace link that should be pointing directly to the project's page

### DIFF
--- a/arp-scan.1
+++ b/arp-scan.1
@@ -637,7 +637,7 @@ using the network interface
 .nf
 $ arp-scan --interface=eth0 192.168.0.0/24
 Interface: eth0, datalink type: EN10MB (Ethernet)
-Starting arp-scan 1.4 with 256 hosts (http://www.nta-monitor.com/tools/arp-scan/)
+Starting arp-scan 1.4 with 256 hosts (http://www.nta-monitor.com/tools-resources/security-tools/arp-scan/)
 192.168.0.1     00:c0:9f:09:b8:db       QUANTA COMPUTER, INC.
 192.168.0.3     00:02:b3:bb:66:98       Intel Corporation
 192.168.0.5     00:02:a5:90:c3:e6       Compaq Computer Corporation
@@ -674,7 +674,7 @@ eth0      Link encap:Ethernet  HWaddr 00:D0:B7:0B:DD:C7
           RX bytes:6184146 (5.8 MiB)  TX bytes:348887835 (332.7 MiB)
 # arp-scan --localnet
 Interface: eth0, datalink type: EN10MB (Ethernet)
-Starting arp-scan 1.4 with 8 hosts (http://www.nta-monitor.com/tools/arp-scan/)
+Starting arp-scan 1.4 with 8 hosts (http://www.nta-monitor.com/tools-resources/security-tools/arp-scan/)
 10.0.84.179     00:02:b3:63:c7:57       Intel Corporation
 10.0.84.177     00:d0:41:08:be:e8       AMIGO TECHNOLOGY CO., LTD.
 10.0.84.180     00:02:b3:bd:82:9b       Intel Corporation
@@ -698,5 +698,5 @@ Roy Hills <Roy.Hills@nta-monitor.com>
 .I http://www.nta-monitor.com/wiki/
 The arp-scan wiki page.
 .PP
-.I http://www.nta-monitor.com/tools/arp-scan/
+.I http://www.nta-monitor.com/tools-resources/security-tools/arp-scan/
 The arp-scan homepage.

--- a/arp-scan.c
+++ b/arp-scan.c
@@ -487,7 +487,7 @@ main(int argc, char *argv[]) {
  *      Display initial message.
  */
    if (!plain_flag) {
-      printf("Starting %s with %u hosts (http://www.nta-monitor.com/tools/arp-scan/)\n",
+      printf("Starting %s with %u hosts (http://www.nta-monitor.com/tools-resources/security-tools/arp-scan/)\n",
           PACKAGE_STRING, num_hosts);
    }
 /*
@@ -1195,7 +1195,7 @@ usage(int status, int detailed) {
    }
    fprintf(stdout, "\n");
    fprintf(stdout, "Report bugs or send suggestions at %s\n", PACKAGE_BUGREPORT);
-   fprintf(stdout, "See the arp-scan homepage at http://www.nta-monitor.com/tools/arp-scan/\n");
+   fprintf(stdout, "See the arp-scan homepage at http://www.nta-monitor.com/tools-resources/security-tools/arp-scan/\n");
    exit(status);
 }
 


### PR DESCRIPTION
the link http://www.nta-monitor.com/tools-resources/security-tools/arp-scan seems to be outdated; it takes you to a listing of their tools rather than the arp-scan tool page itself.

i found all matches and replaced them with what i think the link should be pointing at: http://www.nta-monitor.com/tools-resources/security-tools/arp-scan/

~/Git/arp-scan $ grep -rn http://www.nta-monitor.com/tools/arp-scan/ .
./arp-scan.c:490:      printf("Starting %s with %u hosts (http://www.nta-monitor.com/tools/arp-scan/)\n",
./arp-scan.c:1198:   fprintf(stdout, "See the arp-scan homepage at http://www.nta-monitor.com/tools/arp-scan/\n");
./arp-scan.1:640:Starting arp-scan 1.4 with 256 hosts (http://www.nta-monitor.com/tools/arp-scan/)
./arp-scan.1:677:Starting arp-scan 1.4 with 8 hosts (http://www.nta-monitor.com/tools/arp-scan/)
./arp-scan.1:701:.I http://www.nta-monitor.com/tools/arp-scan/