### PR TITLE
link_open: do not crash when run as non-root

### DIFF
--- a/link-packet-socket.c
+++ b/link-packet-socket.c
@@ -118,6 +118,10 @@ get_hardware_address(const char *if_name, unsigned char hw_address[]) {
    link_t *handle;
 
    handle = link_open(if_name);
+   if(!handle) {
+       err_sys("link_open");
+       return;
+   }
 
 /* Obtain hardware address for specified interface */
    if ((ioctl(handle->fd, SIOCGIFHWADDR, &(handle->ifr))) != 0)


### PR DESCRIPTION
if there's a permission error (or another error), the returned handle
will be null and the subsequent dereference will crash the program.