### PR TITLE
acinclude.m4: use return instead of exit()

### DIFF
--- a/acinclude.m4
+++ b/acinclude.m4
@@ -145,7 +145,7 @@ int does_int64_work()
   return 1;
 }
 main() {
-  exit(! does_int64_work());
+  return(! does_int64_work());
 }],
 [Ac_cachevar=yes],
 [Ac_cachevar=no],
@@ -201,7 +201,7 @@ int does_int64_snprintf_work()
   return 1;
 }
 main() {
-  exit(! does_int64_snprintf_work());
+  return(! does_int64_snprintf_work());
 }],
 [pgac_cv_snprintf_long_long_int_format=$pgac_format; break],
 [],


### PR DESCRIPTION
exit() is defined in stdlib.h which is not included by default
so this will on namespace-clean system such as musl libc raise
the warning "implicit declaration of function 'exit'", which
will cause bogus configure results when the user has -Werror
or -Werror-implicit-function-declaration (highly recommended)
in his CFLAGS.

closes #17