### PR TITLE
Fix use after free in link-packet-socket.c

### DIFF
--- a/link-packet-socket.c
+++ b/link-packet-socket.c
@@ -127,7 +127,7 @@ get_hardware_address(const char *if_name, unsigned char hw_address[]) {
    if ((ioctl(handle->fd, SIOCGIFHWADDR, &(handle->ifr))) != 0)
       err_sys("ioctl");
 
-   link_close(handle);
-
    memcpy(hw_address, handle->ifr.ifr_ifru.ifru_hwaddr.sa_data, ETH_ALEN);
+
+   link_close(handle);
 }


### PR DESCRIPTION
By reordering the memcpy and link_close calls, this file no longer uses memory after free'ing. All tests still work and I don't see anything that could go wrong with this.