### PR TITLE
Update IAB URL

### DIFF
--- a/get-iab
+++ b/get-iab
@@ -34,8 +34,7 @@ use strict;
 use Getopt::Std;
 use LWP::UserAgent;
 #
-my $default_url = 'http://standards.ieee.org/develop/regauth/iab/iab.txt';
-# http://standards.ieee.org/develop/regauth/oui36/oui36.txt
+my $default_url = 'http://standards-oui.ieee.org/iab/iab.txt';
 my $default_filename='ieee-iab.txt';
 #
 my $usage =


### PR DESCRIPTION
The current URL has an invalid certificate, the simplest is to use the same kind of URL as for the OUI URL.