### PR TITLE
configure: try linking to detect stack-protector support

### DIFF
--- a/acinclude.m4
+++ b/acinclude.m4
@@ -243,7 +243,7 @@ AC_DEFUN([GCC_STACK_PROTECT_CC],[
     AC_MSG_CHECKING([whether ${CC} accepts -fstack-protector])
     ssp_old_cflags="$CFLAGS"
     CFLAGS="$CFLAGS -fstack-protector"
-    AC_TRY_COMPILE(,,, ssp_cc=no)
+    AC_TRY_LINK(,,, ssp_cc=no)
     echo $ssp_cc
     if test "X$ssp_cc" = "Xno"; then
       CFLAGS="$ssp_old_cflags"
@@ -259,7 +259,7 @@ AC_DEFUN([GCC_STACK_PROTECT_CXX],[
     AC_MSG_CHECKING([whether ${CXX} accepts -fstack-protector])
     ssp_old_cxxflags="$CXXFLAGS"
     CXXFLAGS="$CXXFLAGS -fstack-protector"
-    AC_TRY_COMPILE(,,, ssp_cxx=no)
+    AC_TRY_LINK(,,, ssp_cxx=no)
     echo $ssp_cxx
     if test "X$ssp_cxx" = "Xno"; then
         CXXFLAGS="$ssp_old_cxxflags"


### PR DESCRIPTION
Even if gcc accepts the -fstack-protector argument, it is possible that
the libssp support library is missing. Detect this by linking instead
of just compiling.

Signed-off-by: Arnout Vandecappelle (Essensium/Mind) <arnout@mind.be>
Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>
[Retrieved from:
https://git.buildroot.net/buildroot/tree/package/arp-scan/0001-configure-try-linking-to-detect-stack-protector-supp.patch]