### PR TITLE
Increased output format flexibility with --format option

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,14 @@
+2021-10-25 Roy Hills <royhills@hotmail.com>
+
+	* format.c: New file containing output format functions.
+
+	* Makefile.am: Added format.c source file to arp_scan_SOURCES
+
+	* utils.c: Added name_to_id() and str_ccmp() functions.
+
+	* arp-scan.c, arp-scan.h, arp-scan.1: Add --format option and output
+	  fields processing code.
+
 2021-10-24 Roy Hills <royhills@hotmail.com>
 
 	* Makefile.am, check-decode: Added checks to test output format with

--- a/Makefile.am
+++ b/Makefile.am
@@ -10,7 +10,7 @@ dist_check_SCRIPTS = check-run1 check-packet check-decode check-host-list
 #
 dist_man_MANS = arp-scan.1 get-oui.1 get-iab.1 arp-fingerprint.1 mac-vendor.5
 #
-arp_scan_SOURCES = arp-scan.c arp-scan.h error.c wrappers.c utils.c mt19937ar.c mt19937ar.h
+arp_scan_SOURCES = arp-scan.c arp-scan.h error.c wrappers.c utils.c mt19937ar.c format.c mt19937ar.h
 arp_scan_LDADD = $(LIBOBJS)
 #
 dist_pkgdata_DATA = ieee-oui.txt ieee-iab.txt mac-vendor.txt

--- a/arp-scan.1
+++ b/arp-scan.1
@@ -5,7 +5,7 @@
 .\" are permitted in any medium without royalty provided the copyright
 .\" notice and this notice are preserved.
 .\"
-.TH ARP-SCAN 1 "October 25, 2022"
+.TH ARP-SCAN 1 "October 26, 2022"
 .\" Please adjust this date whenever revising the man page.
 .SH NAME
 arp-scan \- The ARP scanner
@@ -641,7 +641,47 @@ limit. This can be used in scripts to check if fewer hosts
 respond without having to parse the program output.
 .TP
 .B --format=<s> or -k <s>
-Specify output format string.
+Specify the output format string.
+This option specifies the output format. The format
+string consists of fields using the syntax
+"${field[;width]}". Fields are displayed right-
+aligned unless the width is negative in which case
+left alignment will be used. The following case-
+insensitive field name are recognised:
+.sp
+.TS
+L L .
+IP      Host IP address in dotted quad format
+Name    Host name if --resolve option given
+MAC     Host MAC address xx:xx:xx:xx:xx:xx
+HdrMAC  Ethernet source addr if different
+Vendor  Vendor details string
+Padding Padding after ARP packet in hex if nonzero
+Framing Framing type if not Ethernet_II
+VLAN    802.1Q VLAD ID if present
+Proto   ARP protocol if not 0x0800
+DUP     Packet number for duplicate packets (>1)
+RTT     Round trip time if --rtt option given
+.TE
+.sp
+Only the "ip" and "mac" fields are available if the
+--quiet option is specified.
+.sp
+Any characters that are not fields are output
+verbatim. "\\" introduces escapes:
+.sp
+.TS
+L L .
+\\n	newline
+\\r	carriage return
+\\t	tab
+\\	suppress special meaning for following character
+.TE
+.sp
+You should enclose the --format argument in 'single
+quotes' to protect special characters from the shell.
+.sp
+Example: --format='${ip}\\t${mac}\\t${vendor}'
 .SH FILES
 .TP
 .I /usr/local/share/arp-scan/ieee-oui.txt

--- a/arp-scan.1
+++ b/arp-scan.1
@@ -5,7 +5,7 @@
 .\" are permitted in any medium without royalty provided the copyright
 .\" notice and this notice are preserved.
 .\"
-.TH ARP-SCAN 1 "October 10, 2022"
+.TH ARP-SCAN 1 "October 25, 2022"
 .\" Please adjust this date whenever revising the man page.
 .SH NAME
 arp-scan \- The ARP scanner
@@ -639,6 +639,9 @@ When this option is used arp-scan will exit with status 1 if
 the number of responding hosts is less then the specified
 limit. This can be used in scripts to check if fewer hosts
 respond without having to parse the program output.
+.TP
+.B --format=<s> or -k <s>
+Specify output format string.
 .SH FILES
 .TP
 .I /usr/local/share/arp-scan/ieee-oui.txt

--- a/arp-scan.c
+++ b/arp-scan.c
@@ -1433,6 +1433,32 @@ usage(int status, int detailed) {
       fprintf(stdout, "\t\t\tif fewer hosts respond without having to parse the\n");
       fprintf(stdout, "\t\t\tprogram output.\n");
       fprintf(stdout, "\n--format=<s> or -k <s>\tSpecify output format string.\n");
+      fprintf(stdout, "\t\t\tThis option specifies the output format. The format\n");
+      fprintf(stdout, "\t\t\tstring consists of fields using the syntax\n");
+      fprintf(stdout, "\t\t\t\"${field[;width]}\". Fields are displayed right-\n");
+      fprintf(stdout, "\t\t\taligned unless the width is negative in which case\n");
+      fprintf(stdout, "\t\t\tleft alignment will be used. The following case-\n");
+      fprintf(stdout, "\t\t\tinsensitive field name are recognised:\n");
+      fprintf(stdout, "\n");
+      fprintf(stdout, "\t\t\tIP\tHost IP address\n");
+      fprintf(stdout, "\t\t\tName\tHost name if --resolve option given\n");
+      fprintf(stdout, "\t\t\tMAC\tHost MAC address\n");
+      fprintf(stdout, "\t\t\tHeaderMAC\tEthernet source addr if different\n");
+      fprintf(stdout, "\t\t\tVendor\tVendor details\n");
+      fprintf(stdout, "\t\t\tPadding\tPadding after ARP packet in hex\n");
+      fprintf(stdout, "\t\t\tFraming\tFraming type if not Ethernet_II\n");
+      fprintf(stdout, "\t\t\tVLAN\tVLAD ID if present\n");
+      fprintf(stdout, "\t\t\tARPProto\tARP protocol if not 0x0800\n");
+      fprintf(stdout, "\t\t\tDUP\tPacket number for duplicate packets\n");
+      fprintf(stdout, "\t\t\tRTT\tRound trip time if --rtt option given\n");
+      fprintf(stdout, "\t\t\t\n");
+      fprintf(stdout, "\t\t\tAny characters that are not fields are output\n");
+      fprintf(stdout, "\t\t\tverbatim. \"\\\" introduces escapes:\n");
+      fprintf(stdout, "\t\t\t\n");
+      fprintf(stdout, "\t\t\t\\n newline\n");
+      fprintf(stdout, "\t\t\t\\r carriage return\n");
+      fprintf(stdout, "\t\t\t\\t tab\n");
+      fprintf(stdout, "\t\t\t\\  suppress special meaning for following char\n");
    } else {
       fprintf(stdout, "use \"arp-scan --help\" for detailed information on the available options.\n");
    }

--- a/arp-scan.c
+++ b/arp-scan.c
@@ -1455,6 +1455,9 @@ usage(int status, int detailed) {
       fprintf(stdout, "\t\t\tDUP\tPacket number for duplicate packets (>1)\n");
       fprintf(stdout, "\t\t\tRTT\tRound trip time if --rtt option given\n");
       fprintf(stdout, "\t\t\t\n");
+      fprintf(stdout, "\t\t\tOnly the \"ip\" and \"mac\" fields are available if the\n");
+      fprintf(stdout, "\t\t\t--quiet option is specified.\n");
+      fprintf(stdout, "\t\t\t\n");
       fprintf(stdout, "\t\t\tAny characters that are not fields are output\n");
       fprintf(stdout, "\t\t\tverbatim. \"\\\" introduces escapes:\n");
       fprintf(stdout, "\t\t\t\n");
@@ -1465,6 +1468,8 @@ usage(int status, int detailed) {
       fprintf(stdout, "\t\t\t\n");
       fprintf(stdout, "\t\t\tYou should enclose the --format argument in 'single\n");
       fprintf(stdout, "\t\t\tquotes' to protect special characters from the shell.\n");
+      fprintf(stdout, "\t\t\t\n");
+      fprintf(stdout, "\t\t\tExample: --format='${ip}\\t${mac}\\t${vendor}'\n");
    } else {
       fprintf(stdout, "use \"arp-scan --help\" for detailed information on the available options.\n");
    }

--- a/arp-scan.c
+++ b/arp-scan.c
@@ -679,11 +679,39 @@ display_packet(host_entry *he, arp_ether_ipv4 *arpei,
                const unsigned char *extra_data, size_t extra_data_len,
                int framing, int vlan_id, ether_hdr *frame_hdr,
                const struct pcap_pkthdr *pcap_header) {
+   typedef struct {
+      const char *name;
+      char *value;
+   } field;
+   static field fields[NUMFIELDS] = {
+      {"IP",NULL},
+      {"Name",NULL},
+      {"MAC",NULL},
+      {"HeaderMAC",NULL},	// Need to test this
+      {"Vendor",NULL},
+      {"Padding",NULL},
+      {"Framing",NULL},
+      {"VLAN",NULL},
+      {"ARPProto",NULL},
+      {"DUP",NULL},
+      {"RTT",NULL}
+   };
    char *msg;
    char *cp;
    char *cp2;
    char *ga_err_msg;
    int nonzero=0;
+
+fields[0].value = make_message("%s", my_ntoa(he->addr));
+if (resolve_flag) {
+   cp = get_host_name(he->addr, &ga_err_msg);
+   if (cp) {
+      fields[1].value = make_message("%s", cp);
+   } else {
+      warn_msg("WARNING: getnameinfo() failed for \"%s\": %s",
+               my_ntoa(he->addr), ga_err_msg);
+   }
+}
 /*
  *	Set msg to the IP address of the host entry and a tab.
  */
@@ -843,7 +871,13 @@ display_packet(host_entry *he, arp_ether_ipv4 *arpei,
  *	Print the message.
  */
    printf("%s\n", msg);
+
    free(msg);
+   for (int i=0; i<NUMFIELDS; i++)
+      if (fields[i].value) {
+         free(fields[i].value);
+         fields[i].value = NULL;
+      }
 }
 
 /*

--- a/arp-scan.h
+++ b/arp-scan.h
@@ -22,6 +22,7 @@
  * Date:	11 October 2005
  *
  */
+#define _GNU_SOURCE
 
 /* Includes */
 #ifdef HAVE_CONFIG_H
@@ -35,20 +36,17 @@
 #include <ctype.h>
 #include <stdarg.h>
 #include <errno.h>
+#include <limits.h>
 
 #include <sys/types.h>
 
-/* Integer types */
+/* Integer types (C99) */
 #ifdef HAVE_INTTYPES_H
 #include <inttypes.h>
 #else
 #ifdef HAVE_STDINT_H
 #include <stdint.h>
 #endif
-#endif
-
-#ifdef __CYGWIN__
-#include <windows.h>	/* Include windows.h if compiling under Cygwin */
 #endif
 
 #ifdef HAVE_UNISTD_H
@@ -107,6 +105,10 @@
 
 #ifdef HAVE_IFADDRS_H
 #include <ifaddrs.h>
+#endif
+
+#ifdef __CYGWIN__
+#include <windows.h>	/* Include windows.h if compiling under Cygwin */
 #endif
 
 /* Mersenne Twister random number generator prototypes */
@@ -206,6 +208,26 @@ typedef struct {
    uint32_t ar_tip;		/* Target IP address */
 } arp_ether_ipv4;
 
+/* name to ID lookup map */
+typedef struct {
+   int id;
+   const char *name;
+} id_name_map;
+
+/* output format */
+enum format_type {
+   FORMAT_INVALID,
+   FORMAT_STRING,
+   FORMAT_FIELD
+};
+
+typedef struct format_element {
+        struct format_element *next;
+        enum format_type type;
+        int width;
+        char *data;
+} format_element;
+
 /* Functions */
 
 void err_sys(const char *, ...);
@@ -259,3 +281,6 @@ char *dupstr(const char *);
 void limit_capabilities(void);
 void set_capability(int);
 void drop_capabilities(void);
+int name_to_id(const char *, const id_name_map[]);
+int str_ccmp(const char *, const char *);
+format_element *format_parse(const char *);

--- a/arp-scan.h
+++ b/arp-scan.h
@@ -22,8 +22,6 @@
  * Date:	11 October 2005
  *
  */
-#define _GNU_SOURCE
-
 /* Includes */
 #ifdef HAVE_CONFIG_H
 #include "config.h"

--- a/arp-scan.h
+++ b/arp-scan.h
@@ -173,6 +173,7 @@
 #define DEFAULT_RETRY_SEND 20		/* Default no. of send packet retries */
 #define DEFAULT_RETRY_SEND_INTERVAL 5000  /* Default interval between send
                                         * packet retries in microseconds */
+#define NUMFIELDS 11			/* Number of output fields */
 
 /* Structures */
 

--- a/check-decode
+++ b/check-decode
@@ -492,3 +492,28 @@ fi
 echo "ok"
 rm -f "$ARPSCANOUTPUT"
 rm -f "$EXAMPLEOUTPUT"
+
+# Simple ARP response with custom formatting
+echo "Checking custom formatting using $SAMPLE01 ..."
+cat >"$EXAMPLEOUTPUT" <<_EOF_
+127.0.0.1|08:00:2b:06:07:08|DIGITAL EQUIPMENT CORPORATION
+
+_EOF_
+ARPARGS="--retry=1 --ouifile=$srcdir/ieee-oui.txt --iabfile=$srcdir/ieee-iab.txt --macfile=$srcdir/mac-vendor.txt --format=\${ip}|\${mac}|\${vendor}"
+./arp-scan $ARPARGS --readpktfromfile="$SAMPLE01" 127.0.0.1 | grep -v '^Starting arp-scan ' | grep -v '^Interface: ' | grep -v '^Ending arp-scan ' | grep -v '^[0-9]* packets received ' > "$ARPSCANOUTPUT" 2>&1
+if test $? -ne 0; then
+   rm -f "$ARPSCANOUTPUT"
+   rm -f "$EXAMPLEOUTPUT"
+   echo "FAILED"
+   exit 1
+fi
+cmp -s "$ARPSCANOUTPUT" "$EXAMPLEOUTPUT"
+if test $? -ne 0; then
+   rm -f "$ARPSCANOUTPUT"
+   rm -f "$EXAMPLEOUTPUT"
+   echo "FAILED"
+   exit 1
+fi
+echo "ok"
+rm -f "$ARPSCANOUTPUT"
+rm -f "$EXAMPLEOUTPUT"

--- a/check-decode
+++ b/check-decode
@@ -496,10 +496,10 @@ rm -f "$EXAMPLEOUTPUT"
 # Simple ARP response with custom formatting
 echo "Checking custom formatting using $SAMPLE01 ..."
 cat >"$EXAMPLEOUTPUT" <<_EOF_
-127.0.0.1|08:00:2b:06:07:08|DIGITAL EQUIPMENT CORPORATION
+      127.0.0.1|08:00:2b:06:07:08	DIGITAL EQUIPMENT CORPORATION
 
 _EOF_
-ARPARGS="--retry=1 --ouifile=$srcdir/ieee-oui.txt --iabfile=$srcdir/ieee-iab.txt --macfile=$srcdir/mac-vendor.txt --format=\${ip}|\${mac}|\${vendor}"
+ARPARGS="--retry=1 --ouifile=$srcdir/ieee-oui.txt --iabfile=$srcdir/ieee-iab.txt --macfile=$srcdir/mac-vendor.txt --format=\${ip;15}|\${mac}\\t\${vendor}"
 ./arp-scan $ARPARGS --readpktfromfile="$SAMPLE01" 127.0.0.1 | grep -v '^Starting arp-scan ' | grep -v '^Interface: ' | grep -v '^Ending arp-scan ' | grep -v '^[0-9]* packets received ' > "$ARPSCANOUTPUT" 2>&1
 if test $? -ne 0; then
    rm -f "$ARPSCANOUTPUT"

--- a/format.c
+++ b/format.c
@@ -111,21 +111,6 @@ parsestring(format_element *node, const char *fmt, const char *fmtend) {
    *write = '\0';
 }
 
-void
-format_free(format_element *head) {
-
-   format_element *node;
-
-   while (head) {
-      node = head;
-      head = node->next;
-
-      free(node->data);
-      free(node);
-   }
-}
-
-
 format_element *
 format_parse(const char *fmt) {
 
@@ -143,11 +128,8 @@ format_parse(const char *fmt) {
 
       if (fmt[0] == '$' && fmt[1] == '{') {	/* Field starting ${ */
          fmtend = strchr(fmt, '}');	/* Check for closing brace */
-         if (!fmtend) {
+         if (!fmtend)
             err_msg("ERROR: incorrect show format: missing closing brace");
-            format_free(head);
-            return NULL;
-         }
          parsefield(node, fmt + 2, fmtend - 1);
          fmt = fmtend + 1;
       } else {	/* Not a field so presumably a string */

--- a/format.c
+++ b/format.c
@@ -131,6 +131,7 @@ format_parse(const char *fmt) {
 
    format_element *head, *node;
    const char *fmtend;
+   const char *cp;
 
    head = node = NULL;
 
@@ -153,7 +154,9 @@ format_parse(const char *fmt) {
          fmtend = fmt;
          do {
             fmtend += 1;
-            fmtend = strchrnul(fmtend, '$');	// XXXX GNU Extension XXXX
+            cp = strchr(fmtend, '$');
+            if (!cp)
+               fmtend = strchr(fmtend, '\0');
          } while (fmtend[0] && fmtend[1] != '{');
 
          parsestring(node, fmt, fmtend - 1);

--- a/format.c
+++ b/format.c
@@ -41,7 +41,7 @@ format_element_new(void) {
    return buf;
 }
 
-static int
+static void
 parsefield(format_element *node, const char *fmt, const char *fmtend) {
 
    int len;
@@ -71,11 +71,9 @@ parsefield(format_element *node, const char *fmt, const char *fmtend) {
    node->data = Malloc(len + 1);
    memcpy(node->data, fmt, len);
    node->data[len] = '\0';
-
-   return 0;
 }
 
-static int
+static void
 parsestring(format_element *node, const char *fmt, const char *fmtend) {
 
    int len;
@@ -111,8 +109,6 @@ parsestring(format_element *node, const char *fmt, const char *fmtend) {
       fmt++;
    }
    *write = '\0';
-
-   return 0;
 }
 
 void
@@ -144,20 +140,16 @@ format_parse(const char *fmt) {
       else
          head = node = format_element_new();
 
-      if (fmt[0] == '$' && fmt[1] == '{') {
-         fmtend = strchr(fmt, '}');
+      if (fmt[0] == '$' && fmt[1] == '{') {	/* Field starting ${ */
+         fmtend = strchr(fmt, '}');	/* Check for closing brace */
          if (!fmtend) {
             err_msg("ERROR: incorrect show format: missing closing brace");
             format_free(head);
             return NULL;
          }
-
-         if (!parsefield(node, fmt + 2, fmtend - 1)) {
-            format_free(head);
-            return NULL;
-         }
+         parsefield(node, fmt + 2, fmtend - 1);
          fmt = fmtend + 1;
-      } else {
+      } else {	/* Not a field so presumably a string */
          fmtend = fmt;
          do {
             fmtend += 1;

--- a/format.c
+++ b/format.c
@@ -1,0 +1,176 @@
+/*
+ * The ARP Scanner (arp-scan) is Copyright (C) 2005-2022 Roy Hills
+ *
+ * This file is part of arp-scan.
+ *
+ * arp-scan is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * arp-scan is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with arp-scan.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * You are encouraged to send comments, improvements or suggestions
+ * at the github repository https://github.com/royhills/arp-scan
+ *
+ * Author: Roy Hills
+ * Date: 24 October 2022
+ *
+ * This file contains output format functions, which were adapted
+ * from the dpkg Debian package formatting functions in pkg-format.c.
+ */
+
+#include "arp-scan.h"
+
+static format_element *
+format_element_new(void) {
+   format_element *buf;
+
+   buf = Malloc(sizeof(*buf));
+   buf->type = FORMAT_INVALID;
+   buf->next = NULL;
+   buf->data = NULL;
+   buf->width = 0;
+
+   return buf;
+}
+
+static int
+parsefield(format_element *node, const char *fmt, const char *fmtend) {
+
+   int len;
+   const char *ws;
+
+   len = fmtend - fmt + 1;
+
+   ws = memchr(fmt, ';', len);
+   if (ws) {
+      char *endptr;
+      long w;
+
+      errno = 0;
+      w = strtol(ws + 1, &endptr, 0);
+      if (endptr[0] != '}') {
+         err_msg("ERROR: incorrect show format: invalid character '%c' in field width", *endptr);
+      }
+      if (w < INT_MIN || w > INT_MAX || errno == ERANGE) {
+         err_msg("ERROR: incorrect show format: field width is out of range");
+      }
+
+      node->width = w;
+      len = ws - fmt;
+   }
+
+   node->type = FORMAT_FIELD;
+   node->data = Malloc(len + 1);
+   memcpy(node->data, fmt, len);
+   node->data[len] = '\0';
+
+   return 0;
+}
+
+static int
+parsestring(format_element *node, const char *fmt, const char *fmtend) {
+
+   int len;
+   char *write;
+
+   len = fmtend - fmt + 1;
+
+   node->type = FORMAT_STRING;
+   node->data = write = Malloc(len + 1);
+
+   while (fmt <= fmtend) {
+      if (*fmt == '\\') {
+         fmt++;
+         switch (*fmt) {
+            case 'n':
+               *write = '\n';
+               break;
+            case 't':
+               *write = '\t';
+               break;
+            case 'r':
+               *write = '\r';
+               break;
+            case '\\':
+            default:
+               *write = *fmt;
+               break;
+         }
+      } else {
+         *write = *fmt;
+      }
+      write++;
+      fmt++;
+   }
+   *write = '\0';
+
+   return 0;
+}
+
+void
+format_free(format_element *head) {
+
+   format_element *node;
+
+   while (head) {
+      node = head;
+      head = node->next;
+
+      free(node->data);
+      free(node);
+   }
+}
+
+
+format_element *
+format_parse(const char *fmt) {
+
+   format_element *head, *node;
+   const char *fmtend;
+
+   head = node = NULL;
+
+   while (*fmt) {
+      if (node)
+         node = node->next = format_element_new();
+      else
+         head = node = format_element_new();
+
+      if (fmt[0] == '$' && fmt[1] == '{') {
+         fmtend = strchr(fmt, '}');
+         if (!fmtend) {
+            err_msg("ERROR: incorrect show format: missing closing brace");
+            format_free(head);
+            return NULL;
+         }
+
+         if (!parsefield(node, fmt + 2, fmtend - 1)) {
+            format_free(head);
+            return NULL;
+         }
+         fmt = fmtend + 1;
+      } else {
+         fmtend = fmt;
+         do {
+            fmtend += 1;
+            fmtend = strchrnul(fmtend, '$');	// XXXX GNU Extension XXXX
+         } while (fmtend[0] && fmtend[1] != '{');
+
+         parsestring(node, fmt, fmtend - 1);
+         fmt = fmtend;
+      }
+   }
+
+   if (!head)
+      err_msg("ERROR: output format may not be empty string");
+
+   return head;
+}

--- a/utils.c
+++ b/utils.c
@@ -559,3 +559,76 @@ void drop_capabilities(void)
       err_sys("setuid()");
 #endif
 }
+
+/*
+ *      name_to_id -- Return id associated with given name
+ *
+ *      Inputs:
+ *
+ *      name            The name to find in the map
+ *      id_name_map     Pointer to the id-to-name map
+ *
+ *      Returns:
+ *
+ *      The id associated with the name if an association is found in the
+ *      map, otherwise -1.
+ *
+ *      This function uses a sequential search through the map to find the
+ *      ID and associated name.  This is OK when the map is relatively small,
+ *      but could be time consuming if the map contains a large number of
+ *      entries.
+ *
+ *      The search is case-blind.
+ */
+int
+name_to_id(const char *name, const id_name_map map[]) {
+   int found = 0;
+   int i = 0;
+
+   if (map == NULL)
+      return -1;
+
+   while (map[i].id != -1) {
+      if ((str_ccmp(name,map[i].name)) == 0) {
+         found = 1;
+         break;
+      }
+      i++;
+   }
+
+   if (found)
+      return map[i].id;
+   else
+      return -1;
+}
+
+/*
+ *      str_ccmp  -- Case-blind string comparison
+ *
+ *      Inputs:
+ *
+ *      s1 -- The first input string
+ *      s2 -- The second input string
+ *
+ *      Returns:
+ *
+ *      An integer indicating whether s1 is less than (-1), the same as (0),
+ *      or greater than (1) s2.
+ *
+ *      This function performs the same function, and takes the same arguments
+ *      as the common library function strcasecmp.  This function is used
+ *      instead because strcasecmp is not portable.
+ */
+int
+str_ccmp( const char *s1, const char *s2 ) {
+   int c1, c2;
+
+   for( ; ; s1++, s2++ ){
+      c1 = tolower( (unsigned char) *s1 );
+      c2 = tolower( (unsigned char) *s2 );
+
+      if( c1 > c2            )  return   1;
+      if( c1 < c2            )  return  -1;
+      if( c1 == 0 && c2 == 0 )  return   0;
+   }
+}


### PR DESCRIPTION
Increase the output format flexibility with a *--format* option. This option specifies an output format string consisting of text and fields: text is output verbatim; fields output the appropriate value with an optional width and right or left justification. When *--format* is specified, the details for each responding host are displayed according to the format string.

The concept is based on that used by the Debian *dpkg-query* command for custom output formats with the *--showformat* option.

Resolves #57 
Resolves #71 