### PR TITLE
Change format short option from -k to -F

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,9 +1,9 @@
-2022-xx-xx Roy Hills <royhills@hotmail.com>
+2022-11-02 Roy Hills <royhills@hotmail.com>
 
-	* strlcat.c: removed. arp-scan only uses strlcpy(), so we don't need
-	  to ship replacement source code for strcat() as well.
+	* arp-scan.c, arp-scan.1.dist: Change --format short option character
+	  from -k to -F. The -F character became free when the --iabfile
+	  option was removed, and is a more logical choice.
 
-	* configure.ac, strlcpy.h: Removed references to strlcat.
 
 2022-11-01 Roy Hills <royhills@hotmail.com>
 
@@ -22,6 +22,11 @@
 	  redirect from the http to https site.
 
 	* ieee-oui.txt: Updated from IEEE website.
+
+	* strlcat.c: removed. arp-scan only uses strlcpy(), so we don't need
+	  to ship replacement source code for strcat() as well.
+
+	* configure.ac, strlcpy.h: Removed references to strlcat.
 
 2022-10-31 Roy Hills <royhills@hotmail.com>
 

--- a/arp-scan.1.dist
+++ b/arp-scan.1.dist
@@ -627,7 +627,7 @@ the number of responding hosts is less then the specified
 limit. This can be used in scripts to check if fewer hosts
 respond without having to parse the program output.
 .TP
-\fB--format\fP=\fI<s>\fP or \fB-k \fI<s>\fR
+\fB--format\fP=\fI<s>\fP or \fB-F \fI<s>\fR
 Specify the output format string.
 This option specifies the output format. The format
 string consists of fields using the syntax

--- a/arp-scan.c
+++ b/arp-scan.c
@@ -1425,7 +1425,7 @@ usage(int status, int detailed) {
       fprintf(stdout, "\t\t\tspecified limit. This can be used in scripts to check\n");
       fprintf(stdout, "\t\t\tif fewer hosts respond without having to parse the\n");
       fprintf(stdout, "\t\t\tprogram output.\n");
-      fprintf(stdout, "\n--format=<s> or -k <s>\tSpecify the output format string.\n");
+      fprintf(stdout, "\n--format=<s> or -F <s>\tSpecify the output format string.\n");
       fprintf(stdout, "\t\t\tThis option specifies the output format. The format\n");
       fprintf(stdout, "\t\t\tstring consists of fields using the syntax\n");
       fprintf(stdout, "\t\t\t\"${field[;width]}\". Fields are displayed right-\n");
@@ -2073,14 +2073,14 @@ process_options(int argc, char *argv[]) {
       {"randomseed", required_argument, 0, OPT_RANDOMSEED},
       {"limit", required_argument, 0, 'M'},
       {"resolve", no_argument, 0, 'd'},
-      {"format", required_argument, 0, 'k'},
+      {"format", required_argument, 0, 'F'},
       {0, 0, 0, 0}
    };
 /*
  * available short option characters:
  *
- * lower:       --c-e----j---------------z
- * UPPER:       --C--FG--JK---------U--X-Z
+ * lower:       --c-e----jk--------------z
+ * UPPER:       --C---G--JK---------U--X-Z
  * Digits:      0123456789
  */
    const char *short_options =
@@ -2242,7 +2242,7 @@ process_options(int argc, char *argv[]) {
          case 'd':	/* --resolve */
             resolve_flag = 1;
             break;
-         case 'k':	/* --format */
+         case 'F':	/* --format */
             format=format_parse(optarg);
             break;
          default:	/* Unknown option */


### PR DESCRIPTION
Change the --format short option character from -k to -F. The -F character became free when the --iabfile option was removed by https://github.com/royhills/arp-scan/pull/79, and is a more logical choice.