### PR TITLE
Display warning for unavailable fields

### DIFF
--- a/TODO
+++ b/TODO
@@ -9,7 +9,3 @@ MPLS tag support (Label Distribution Using ARP: draft-kompella-mpls-larp-11).
 
 Add support for Cisco ISL VLANs in addition to 802.1Q VLANs. Suggested by
 Daniel at commonexploits.
-
-Modify the IEEE MAC/Vendor mapping code and scripts to cater for the
-OUI registry restructuring detailed in:
-http://tools.ietf.org/html/draft-ieee-rac-oui-restructuring-01

--- a/arp-scan.c
+++ b/arp-scan.c
@@ -941,12 +941,12 @@ display_packet(host_entry *he, arp_ether_ipv4 *arpei,
       msg=dupstr("");	/* Set msg to empty string */
       for (fmt=format; fmt; fmt=fmt->next) {
          if (fmt->type == FORMAT_FIELD) {
-            if ((idx=name_to_id(fmt->data, fields_map)) != -1) {
+            if ((idx=name_to_id(fmt->data, fields_map)) != -1 && fields[idx].value) {
                cp = msg;
                msg = make_message("%s%*s", cp, fmt->width, fields[idx].value);
                free(cp);
             } else {	/* Field name not found in map */
-               warn_msg("WARNING: Field name ${%s} is not known", fmt->data);
+               warn_msg("WARNING: Field ${%s} unknown or not available", fmt->data);
             }
          } else if (fmt->type == FORMAT_STRING) {
             cp = msg;

--- a/check-decode
+++ b/check-decode
@@ -496,11 +496,11 @@ rm -f "$EXAMPLEOUTPUT"
 # Simple ARP response with custom formatting
 echo "Checking custom formatting using $SAMPLE01 ..."
 cat >"$EXAMPLEOUTPUT" <<_EOF_
-      127.0.0.1|08:00:2b:06:07:08	DIGITAL EQUIPMENT CORPORATION
-
+WARNING: Field \${xyz} unknown or not available
+      127.0.0.1|08:00:2b:06:07:08\	DIGITAL EQUIPMENT CORPORATION,
 _EOF_
-ARPARGS="--retry=1 --ouifile=$srcdir/ieee-oui.txt --macfile=$srcdir/mac-vendor.txt --format=\${ip;15}|\${mac}\\t\${vendor}"
-./arp-scan $ARPARGS --readpktfromfile="$SAMPLE01" 127.0.0.1 | grep -v '^Starting arp-scan ' | grep -v '^Interface: ' | grep -v '^Ending arp-scan ' | grep -v '^[0-9]* packets received ' > "$ARPSCANOUTPUT" 2>&1
+ARPARGS="--plain --retry=1 --ouifile=$srcdir/ieee-oui.txt --macfile=$srcdir/mac-vendor.txt --format=\${ip;15}|\${mac}\\\\\t\${vendor},\${xyz}"
+./arp-scan $ARPARGS --readpktfromfile="$SAMPLE01" 127.0.0.1 > "$ARPSCANOUTPUT" 2>&1
 if test $? -ne 0; then
    rm -f "$ARPSCANOUTPUT"
    rm -f "$EXAMPLEOUTPUT"


### PR DESCRIPTION
Display `WARNING: Field ${%s} unknown or not available` if a field name is unknown (e.g. `${xyz}`) or unavailable (e.g. `${rtt}` when the `--rtt` option has not been specified).

Previously a warning was only given for unknown fields, and unavailable fields were NULL.