### PR TITLE
Install mac-vendor.txt to $(sysconfdir)/$(PACKAGE) instead of $(pkgdatadir)

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,13 @@
+2022-11-06 Roy Hills <royhills@hotmail.com>
+
+	* Makefile.am: Install mac-vendor.txt to $(sysconfdir)/$(PACKAGE) instead
+	  of $(pkgdatadir). With a default ./configure this will be
+	  /usr/local/etc/arp-scan.  For a binary package it will typically be
+	  /etc/arp-scan. This change is because users may add local entries to
+	  mac-vendor.txt that they want to preserve between package upgrades.
+
+	* arp-scan.c, arp-scan.1.dist: Update file paths for mac-vendor.txt.
+
 2022-11-03 Roy Hills <royhills@hotmail.com>
 
 	* arp-scan.c, arp-scan.h: Don't display long usage message for unrecognised

--- a/Makefile.am
+++ b/Makefile.am
@@ -1,6 +1,7 @@
 # Process this file with automake to produce Makefile.in
 #
-AM_CPPFLAGS = -DPKGDATADIR=\"$(pkgdatadir)\"
+pkgsysconfdir = $(sysconfdir)/$(PACKAGE)
+AM_CPPFLAGS = -DPKGDATADIR=\"$(pkgdatadir)\" -DPKGSYSCONFDIR=\"$(sysconfdir)\"
 #
 bin_PROGRAMS = arp-scan
 #
@@ -13,14 +14,15 @@ dist_man_MANS = arp-scan.1 get-oui.1 arp-fingerprint.1 mac-vendor.5
 arp_scan_SOURCES = arp-scan.c arp-scan.h error.c wrappers.c utils.c mt19937ar.c format.c mt19937ar.h
 arp_scan_LDADD = $(LIBOBJS)
 #
-dist_pkgdata_DATA = ieee-oui.txt mac-vendor.txt
+dist_pkgsysconf_DATA = mac-vendor.txt
+dist_pkgdata_DATA = ieee-oui.txt
 #
 TESTS = $(dist_check_SCRIPTS)
 EXTRA_DIST = arp-scan.1.dist get-oui.1.dist pkt-simple-request.dat pkt-custom-request.dat pkt-custom-request-padding.dat pkt-custom-request-llc.dat pkt-custom-request-vlan.dat pkt-simple-response.pcap pkt-padding-response.pcap pkt-vlan-response.pcap pkt-llc-response.pcap pkt-net1921681-response.pcap pkt-trailer-response.pcap pkt-vlan-llc-response.pcap pkt-custom-request-vlan-llc.dat pkt-dup-response.pcap pkt-diff-frame-addr.pcap pkt-local-admin.pcap pkt-ieee-regcheck.pcap
 #
 # Substitute autoconf pkgdatadir variable in arp-scan.1 manpage
 CLEANFILES = arp-scan.1 get-oui.1
-do_subst = sed -e 's,[@]PKGDATADIR[@],$(pkgdatadir),g'
+do_subst = sed -e 's,[@]PKGDATADIR[@],$(pkgdatadir),g;s,[@]PKGSYSCONFDIR[@],$(pkgsysconfdir),g'
 arp-scan.1: arp-scan.1.dist Makefile
 	$(do_subst) < $(srcdir)/arp-scan.1.dist > arp-scan.1
 get-oui.1: get-oui.1.dist Makefile

--- a/arp-scan.1.dist
+++ b/arp-scan.1.dist
@@ -283,7 +283,7 @@ If that is not found \fI@PKGDATADIR@/ieee-oui.txt\fP is used.
 \fB--macfile\fP=\fI<s>\fP or \fB-O \fI<s>\fR
 Use custom vendor mapping file \fI<s>\fP.
 Default is \fImac-vendor.txt\fP in the current directory.
-If that is not found \fI@PKGDATADIR@/mac-vendor.txt\fP is used.
+If that is not found \fI@PKGSYSCONFDIR@/mac-vendor.txt\fP is used.
 .SS "Output Format Control"
 .TP
 .BR --quiet " or " -q
@@ -569,7 +569,7 @@ specified limit.
 .I @PKGDATADIR@/ieee-oui.txt
 List of IEEE OUI (Organisationally Unique Identifier) to vendor mappings.
 .TP
-.I @PKGDATADIR@/mac-vendor.txt
+.I @PKGSYSCONFDIR@/mac-vendor.txt
 List of other Ethernet MAC to vendor mappings, including local additions.
 .SH EXAMPLES
 .SS "Simple Scan"

--- a/arp-scan.c
+++ b/arp-scan.c
@@ -376,7 +376,7 @@ main(int argc, char *argv[]) {
                   count, fn);
       free(fn);
 
-      fn = get_mac_vendor_filename(macfilename, PKGDATADIR, MACFILENAME);
+      fn = get_mac_vendor_filename(macfilename, PKGSYSCONFDIR, MACFILENAME);
       count = add_mac_vendor(fn);
       if (verbose > 1 && count > 0)
          warn_msg("DEBUG: Loaded %d MAC/Vendor entries from %s.",
@@ -1301,7 +1301,7 @@ usage(void) {
    fprintf(stdout, "\n--macfile=<s> or -O <s>\tUse custom vendor mapping file <s>.\n");
    fprintf(stdout, "\t\t\tDefault is %s in the current directory.\n", MACFILENAME);
    fprintf(stdout, "\t\t\tIf that is not found\n");
-   fprintf(stdout, "\t\t\t%s/%s is used.\n", PKGDATADIR, MACFILENAME);
+   fprintf(stdout, "\t\t\t%s/%s is used.\n", PKGSYSCONFDIR, MACFILENAME);
    fprintf(stdout, "\n--srcaddr=<m> or -S <m> Set the source Ethernet MAC address.\n");
    fprintf(stdout, "\t\t\tThe default is the Ethernet address of the outgoing\n");
    fprintf(stdout, "\t\t\tinterface. This sets the 48-bit hardware address in\n");


### PR DESCRIPTION
Install `mac-vendor.txt` to `$(sysconfdir)/$(PACKAGE)` instead of `$(pkgdatadir)`. With a default `./configure` this will be `/usr/local/etc/arp-scan`.  For a binary package it will typically be `/etc/arp-scan`. This change is because users may add local entries to `mac-vendor.txt` that they want to preserve between package upgrades.