### PR TITLE
Move error tests to new check-error script

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -4,6 +4,12 @@
 	  "for (i=0..." format. This caused errors with old toolchain e.g.
 	  autoconf 2.69/gcc 4.9.2 on Debian Jessie.
 
+	* check-run1: Moved error checks to check-error.
+
+	* check-error: New file to check error conditions.
+
+	* Makefile.am: Updated list of test scripts.
+
 2022-11-06 Roy Hills <royhills@hotmail.com>
 
 	* Makefile.am: Install mac-vendor.txt to $(sysconfdir)/$(PACKAGE)

--- a/Makefile.am
+++ b/Makefile.am
@@ -7,7 +7,7 @@ bin_PROGRAMS = arp-scan
 #
 dist_bin_SCRIPTS = get-oui get-iab arp-fingerprint
 #
-dist_check_SCRIPTS = check-run1 check-packet check-decode check-host-list check-ieee-reg
+dist_check_SCRIPTS = check-run1 check-packet check-decode check-host-list check-ieee-reg check-error
 #
 dist_man_MANS = arp-scan.1 get-oui.1 arp-fingerprint.1 mac-vendor.5
 #

--- a/check-error
+++ b/check-error
@@ -19,23 +19,22 @@
 # check-run1 -- Shell script to test arp-scan basic functionality
 #
 # Author: Roy Hills
-# Date: 9 March 2006
+# Date: 7 November 2022
 #
-# This shell script checks that "arp-scan --help" and "arp-scan --version"
-# work.  These options don't use much of the arp-scan functionality, so if
-# they fail, then there is a fundamental problem with the program.
+# This shell script checks various error conditions.
 #
-ARPSCANOUTPUT=/tmp/arp-scan-test.$$.tmp
+ARPSCANOUTPUT=/tmp/arp-scan-output.$$.tmp
+SAMPLE01="$srcdir/pkt-simple-response.pcap"
 
-# Check arp-scan --help
-echo "Checking arp-scan --help ..."
-./arp-scan --help > "$ARPSCANOUTPUT"
-if test $? -ne 0; then
+# Check invalid option - should have non-zero exit status
+echo "Checking arp-scan --xyz (invalid option) ..."
+./arp-scan --xyz > "$ARPSCANOUTPUT" 2>&1
+if test $? -eq 0; then
    rm -f "$ARPSCANOUTPUT"
    echo "FAILED"
    exit 1
 fi
-grep '^Report bugs or send suggestions at ' "$ARPSCANOUTPUT" >/dev/null
+grep '^Use "arp-scan --help" for detailed information' "$ARPSCANOUTPUT" >/dev/null
 if test $? -ne 0; then
    rm -f "$ARPSCANOUTPUT"
    echo "FAILED"
@@ -44,15 +43,15 @@ fi
 echo "ok"
 rm -f "$ARPSCANOUTPUT"
 
-# Check arp-scan --version
-echo "Checking arp-scan --version ..."
-./arp-scan --version > "$ARPSCANOUTPUT"
-if test $? -ne 0; then
+# Check no target hosts - should have non-zero exit status
+echo "Checking arp-scan without target hosts ..."
+./arp-scan > "$ARPSCANOUTPUT" 2>&1
+if test $? -eq 0; then
    rm -f "$ARPSCANOUTPUT"
    echo "FAILED"
    exit 1
 fi
-grep '^Copyright (C) ' "$ARPSCANOUTPUT" >/dev/null
+grep '^ERROR: No target hosts on command line ' "$ARPSCANOUTPUT" >/dev/null
 if test $? -ne 0; then
    rm -f "$ARPSCANOUTPUT"
    echo "FAILED"
@@ -60,3 +59,22 @@ if test $? -ne 0; then
 fi
 echo "ok"
 rm -f "$ARPSCANOUTPUT"
+
+# Try to use a file that doesn't exist - should have non-zero exit status
+echo "Checking arp-scan with non existent file ..."
+ARPARGS="--retry=1"
+./arp-scan $ARPARGS -f xxxFUNNYxxx --readpktfromfile="$SAMPLE01" > "$ARPSCANOUTPUT" 2>&1
+if test $? -eq 0; then
+   rm -f "$ARPSCANOUTPUT"
+   echo "FAILED"
+   exit 1
+fi
+grep '^Cannot open xxxFUNNYxxx:' "$ARPSCANOUTPUT" >/dev/null
+if test $? -ne 0; then
+   rm -f "$ARPSCANOUTPUT"
+   echo "FAILED"
+   exit 1
+fi
+echo "ok"
+rm -f "$ARPSCANOUTPUT"
+

--- a/check-error
+++ b/check-error
@@ -60,8 +60,8 @@ fi
 echo "ok"
 rm -f "$ARPSCANOUTPUT"
 
-# Try to use a file that doesn't exist - should have non-zero exit status
-echo "Checking arp-scan with non existent file ..."
+# Try to use a host input file that doesn't exist - should have non-zero exit status
+echo "Checking arp-scan with non existent host file ..."
 ARPARGS="--retry=1"
 ./arp-scan $ARPARGS -f xxxFUNNYxxx --readpktfromfile="$SAMPLE01" > "$ARPSCANOUTPUT" 2>&1
 if test $? -eq 0; then
@@ -78,3 +78,20 @@ fi
 echo "ok"
 rm -f "$ARPSCANOUTPUT"
 
+# Try to use a non-existant mac/vendor mapping file - should warn and continue
+echo "Checking arp-scan with non existent mac/vendor file ..."
+ARPARGS="--retry=1"
+./arp-scan $ARPARGS -O xxxFUNNYxxx --readpktfromfile="$SAMPLE01" 127.0.0.1 > "$ARPSCANOUTPUT" 2>&1
+if test $? -ne 0; then
+   rm -f "$ARPSCANOUTPUT"
+   echo "FAILED"
+   exit 1
+fi
+grep '^WARNING: Cannot open MAC/Vendor file xxxFUNNYxxx:' "$ARPSCANOUTPUT" >/dev/null
+if test $? -ne 0; then
+   rm -f "$ARPSCANOUTPUT"
+   echo "FAILED"
+   exit 1
+fi
+echo "ok"
+rm -f "$ARPSCANOUTPUT"


### PR DESCRIPTION
Move tests for errors from check-run1 to new check-error script. Add some new tests to increase code coverage.