### PR TITLE
Added system info gathering commands to c-cpp.yml

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -36,5 +36,9 @@ jobs:
     - name: print info
       run: |
         uname -a
+	lsb_release -a
+	sw_vers
         gcc --version
+	autoconf --version
+	automake --version
         ./arp-scan --version


### PR DESCRIPTION
Added system information gathering commands to c-cpp.yml: `lsb_release -a` (ubuntu), `sw_vers` (macOS), `autoconf --version` and `automake --version`.