### PR TITLE
Install libcap-dev for code-coverage and codeql runs

### DIFF
--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -17,7 +17,7 @@ jobs:
       - name: install libpcap and lcov
         run: |
           sudo apt-get update -qq
-          sudo apt-get install -qq libpcap0.8-dev lcov
+          sudo apt-get install -qq libpcap0.8-dev libcap-dev lcov
       - name: autoreconf
         run: autoreconf --install
       - name: configure with gcov

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -42,7 +42,7 @@ jobs:
     - name: install libpcap
       run: |
         sudo apt-get update -qq
-        sudo apt-get install -qq libpcap0.8-dev
+        sudo apt-get install -qq libpcap0.8-dev libcap-dev
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL


### PR DESCRIPTION
Install libcap-dev for all Linux action runs so arp-scan gets built with POSIX.1e capabilities support.
