### PR TITLE
Install executable with CAP_NET_RAW capability or fallback to SUID

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,9 @@
+2022-11-11 Roy Hills <royhills@hotmail.com>
+
+	* Makefile.am: Added install-exec-hook to set the CAP_NET_RAW
+	  capability on the arp-scan executable if "setcap" exists and
+	  works.  Otherwise falls back to setting the SUID bit.
+
 2022-11-09 Roy Hills <royhills@hotmail.com>
 
 	* check-error, check-options, Makefile.am: Added new tests to check

--- a/Makefile.am
+++ b/Makefile.am
@@ -29,3 +29,19 @@ arp-scan.1: arp-scan.1.dist Makefile
 	$(do_subst) < $(srcdir)/arp-scan.1.dist > arp-scan.1
 get-oui.1: get-oui.1.dist Makefile
 	$(do_subst) < $(srcdir)/get-oui.1.dist > get-oui.1
+# Install arp-scan with cap_net_raw if possible, otherwise SUID root
+install-exec-hook:
+	@if command -v setcap > /dev/null; then \
+	if setcap cap_net_raw+p $(DESTDIR)$(bindir)/arp-scan$(EXEEXT); then \
+	echo "setcap cap_net_raw+p $(DESTDIR)$(bindir)/arp-scan$(EXEEXT)"; \
+	chmod u-s $(DESTDIR)$(bindir)/arp-scan$(EXEEXT); \
+	else \
+	echo "Setcap failed on $(DESTDIR)$(bindir)/arp-scan$(EXEEXT), falling back to setuid" >&2; \
+	echo "chmod u+s $(DESTDIR)$(bindir)/arp-scan$(EXEEXT)";  \
+	chmod u+s $(DESTDIR)$(bindir)/arp-scan$(EXEEXT);  \
+	fi \
+	else \
+	echo "Setcap is not installed, falling back to setuid" >&2 ; \
+	echo "chmod u+s $(DESTDIR)$(bindir)/arp-scan$(EXEEXT)" ;\
+	chmod u+s $(DESTDIR)$(bindir)/arp-scan$(EXEEXT) ;\
+	fi

--- a/NEWS.md
+++ b/NEWS.md
@@ -76,6 +76,10 @@ release.  For more details please read the ChangeLog file.**
 * Note that the `get-iab` script and the `ieee-iab.txt` file have been
   removed from this version.
 
+* `Makefile.am` contains an `install-exec-hook` that will set `CAP_NET_RAW` on
+  the arp-scan executable if it can, otherwise it will install it SUID. you can
+  remove this install-exec-hook code if this behaviour is not desired.
+
 * Note that the `mac-vendor.txt` file has been moved to
   `$(sysconfdir)/$(PACKAGE)` as detailed above. Users may make local changes
   to this file and upstream changes should be infrequent. Please mark this

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,7 @@
 **This file gives a brief overview of the major changes between each arp-scan
 release.  For more details please read the ChangeLog file.**
 
-# YYYY-MM-DD arp-scan 1.9.9 (in progress)
+# 2022-MM-DD arp-scan 1.10 (in progress)
 
 ## New Features
 
@@ -28,6 +28,9 @@ release.  For more details please read the ChangeLog file.**
     e.g. `--pcapsavefile` or `--ouifile` in user directories.
   - --version displays `Built with libcap POSIX.1e capability support` (or not)
   - Adapted from the iputils-ping capabilities code.
+  - `make install` will install the arp-scan executable with the `CAP_NET_RAW`
+     capability if `setcap` is available and works. Otherwise will fallback to
+     SUID.
 
 * **--format option allows flexible output format.**
 
@@ -62,19 +65,21 @@ release.  For more details please read the ChangeLog file.**
 * **arp-scan now prints a brief error message instead of half a page of usage
   text for unknown options.**
 
-## Notes for package maintainers
+## Package Maintainers Notes
 
 * If you are packaging for Linux please build with libcap POSIX.1e capability
-  support if possible.
+  support if your distribution allows it.
 
 * If you are packaging for a Debian based system, the get-oui Perl script can
-  easily be edited to use the ieee-data package.
+  easily be edited to use the Debian ieee-data package.
 
 * Note that the `get-iab` script and the `ieee-iab.txt` file have been
   removed from this version.
 
 * Note that the `mac-vendor.txt` file has been moved to
-  `$(sysconfdir)/$(PACKAGE)` as detailed above.
+  `$(sysconfdir)/$(PACKAGE)` as detailed above. Users may make local changes
+  to this file and upstream changes should be infrequent. Please mark this
+  as a configuration file if possible so upgrades don't overwrite user changes.
 
 * If you have any problems packaging arp-scan, please open an issue on github.
 


### PR DESCRIPTION
`make install` will install the arp-scan executable with CAP_NET_RAW capability if it can, otherwise (if the `setcap` command doesn't exist or if it fails) then it will fallback to using SUID.

Note that `setcap` can fail if the arp-scan exectable is installed to a filesystem that does not support extended attributes, e.g. NFS.