### PR TITLE
Correct mac-vendor.txt directory location

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,9 @@
+2022-11-25 Roy Hills <royhills@hotmail.com>
+
+	* Makefile.am: Add $(PACKAGE) to the PKGSYSCONFDIR macro definition
+	  so arp-scan looks in the correct directory for the mac-vendor.txt
+	  file.  Thanks to Richard Hoyle for reporting this bug.
+
 2022-11-11 Roy Hills <royhills@hotmail.com>
 
 	* Makefile.am: Added install-exec-hook to set the CAP_NET_RAW

--- a/Makefile.am
+++ b/Makefile.am
@@ -1,7 +1,7 @@
 # Process this file with automake to produce Makefile.in
 #
 pkgsysconfdir = $(sysconfdir)/$(PACKAGE)
-AM_CPPFLAGS = -DPKGDATADIR=\"$(pkgdatadir)\" -DPKGSYSCONFDIR=\"$(sysconfdir)\"
+AM_CPPFLAGS = -DPKGDATADIR=\"$(pkgdatadir)\" -DPKGSYSCONFDIR=\"$(sysconfdir)/$(PACKAGE)\"
 #
 bin_PROGRAMS = arp-scan
 #


### PR DESCRIPTION
Modify the `PKGSYSCONFDIR` macro definition in `Makefile.am` so `arp-scan` looks in the correct directory for the `mac-vendor.txt` file.

Fixes https://github.com/royhills/arp-scan/issues/107
