### PR TITLE
Standardise code formatting

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -4,6 +4,9 @@
 	  so arp-scan looks in the correct directory for the mac-vendor.txt
 	  file.  Thanks to Richard Hoyle for reporting this bug.
 
+	* error.c, format.c, link-bpf.c, link-dlpi.c, link-packet-socket.c,
+	  wrappers.c, utils.c, arp-scan.c: Standardise code formatting.
+
 2022-11-11 Roy Hills <royhills@hotmail.com>
 
 	* Makefile.am: Added install-exec-hook to set the CAP_NET_RAW

--- a/arp-scan.c
+++ b/arp-scan.c
@@ -36,62 +36,62 @@
 #include "arp-scan.h"
 
 /* Global variables */
-static host_entry *helist = NULL;	/* Array of host entries */
-static host_entry **helistptr;		/* Array of pointers to host entries */
-static host_entry **cursor;		/* Pointer to current host entry ptr */
-static unsigned num_hosts = 0;		/* Number of entries in the list */
-static unsigned responders = 0;		/* Number of hosts which responded */
-static unsigned live_count;		/* Number of entries awaiting reply */
-static int verbose=0;			/* Verbose level */
-static char *filename;			/* Target list file name */
-static int filename_flag=0;		/* Set if using target list file */
-static int random_flag=0;		/* Randomise the list */
-static int numeric_flag=0;		/* IP addresses only */
-static unsigned interval=0;		/* Desired interval between packets */
-static unsigned bandwidth=DEFAULT_BANDWIDTH; /* Bandwidth in bits per sec */
-static unsigned retry = DEFAULT_RETRY;	/* Number of retries */
-static unsigned timeout = DEFAULT_TIMEOUT; /* Per-host timeout */
-static float backoff_factor = DEFAULT_BACKOFF_FACTOR;	/* Backoff factor */
-static int snaplen = SNAPLEN;		/* Pcap snap length */
-static char *if_name=NULL;		/* Interface name, e.g. "eth0" */
-static int quiet_flag=0;		/* Don't decode the packet */
-static int ignore_dups=0;		/* Don't display duplicate packets */
-static uint32_t arp_spa;		/* Source IP address */
-static int arp_spa_flag=0;		/* Source IP address specified */
-static int arp_spa_is_tpa=0;		/* Source IP is dest IP */
-static unsigned char arp_sha[ETH_ALEN];	/* Source Ethernet MAC Address */
-static int arp_sha_flag=0;		/* Source MAC address specified */
-static char *ouifilename = NULL;	/* OUI filename */
-static char *macfilename = NULL;	/* MAC filename */
-static char *pcap_savefile = NULL;	/* pcap savefile filename */
-static int arp_op=DEFAULT_ARP_OP;	/* ARP Operation code */
-static int arp_hrd=DEFAULT_ARP_HRD;	/* ARP hardware type */
-static int arp_pro=DEFAULT_ARP_PRO;	/* ARP protocol */
-static int arp_hln=DEFAULT_ARP_HLN;	/* Hardware address length */
-static int arp_pln=DEFAULT_ARP_PLN;	/* Protocol address length */
-static int eth_pro=DEFAULT_ETH_PRO;	/* Ethernet protocol type */
+static host_entry *helist = NULL; /* Array of host entries */
+static host_entry **helistptr;    /* Array of pointers to host entries */
+static host_entry **cursor;       /* Pointer to current host entry ptr */
+static unsigned num_hosts = 0;    /* Number of entries in the list */
+static unsigned responders = 0;   /* Number of hosts which responded */
+static unsigned live_count;       /* Number of entries awaiting reply */
+static int verbose = 0;           /* Verbose level */
+static char *filename;            /* Target list file name */
+static int filename_flag = 0;     /* Set if using target list file */
+static int random_flag = 0;       /* Randomise the list */
+static int numeric_flag = 0;      /* IP addresses only */
+static unsigned interval = 0;     /* Desired interval between packets */
+static unsigned bandwidth = DEFAULT_BANDWIDTH; /* Bandwidth in bits per sec */
+static unsigned retry = DEFAULT_RETRY;       /* Number of retries */
+static unsigned timeout = DEFAULT_TIMEOUT;   /* Per-host timeout */
+static float backoff_factor = DEFAULT_BACKOFF_FACTOR; /* Backoff factor */
+static int snaplen = SNAPLEN;           /* Pcap snap length */
+static char *if_name = NULL;            /* Interface name, e.g. "eth0" */
+static int quiet_flag = 0;              /* Don't decode the packet */
+static int ignore_dups = 0;             /* Don't display duplicate packets */
+static uint32_t arp_spa;                /* Source IP address */
+static int arp_spa_flag = 0;            /* Source IP address specified */
+static int arp_spa_is_tpa = 0;          /* Source IP is dest IP */
+static unsigned char arp_sha[ETH_ALEN]; /* Source Ethernet MAC Address */
+static int arp_sha_flag = 0;            /* Source MAC address specified */
+static char *ouifilename = NULL;        /* OUI filename */
+static char *macfilename = NULL;        /* MAC filename */
+static char *pcap_savefile = NULL;      /* pcap savefile filename */
+static int arp_op = DEFAULT_ARP_OP;     /* ARP Operation code */
+static int arp_hrd = DEFAULT_ARP_HRD;   /* ARP hardware type */
+static int arp_pro = DEFAULT_ARP_PRO;   /* ARP protocol */
+static int arp_hln = DEFAULT_ARP_HLN;   /* Hardware address length */
+static int arp_pln = DEFAULT_ARP_PLN;   /* Protocol address length */
+static int eth_pro = DEFAULT_ETH_PRO;   /* Ethernet protocol type */
 static unsigned char arp_tha[6] = {0, 0, 0, 0, 0, 0};
 static unsigned char target_mac[6] = {0xff, 0xff, 0xff, 0xff, 0xff, 0xff};
 static unsigned char source_mac[6];
 static int source_mac_flag = 0;
-static unsigned char *padding=NULL;
-static size_t padding_len=0;
-static int localnet_flag=0;		/* Scan local network */
-static int llc_flag=0;			/* Use 802.2 LLC with SNAP */
-static int ieee_8021q_vlan=-1;		/* Use 802.1Q VLAN tagging if >= 0 */
-static int pkt_write_file_flag=0;	/* Write packet to file flag */
-static int pkt_read_file_flag=0;	/* Read packet from file flag */
-static char *pkt_filename = NULL;	/* Read/Write packet to file filename */
-static int write_pkt_to_file=0;		/* Write packet to file for debugging */
-static int rtt_flag=0;			/* Display round-trip time */
-static pcap_dumper_t *pcap_dump_handle = NULL;	/* pcap savefile handle */
-static int plain_flag=0;		/* Only show host information */
-static int resolve_flag=0;		/* Resolve IP addresses to hostnames */
-unsigned int random_seed=0;
+static unsigned char *padding = NULL;
+static size_t padding_len = 0;
+static int localnet_flag = 0;           /* Scan local network */
+static int llc_flag = 0;                /* Use 802.2 LLC with SNAP */
+static int ieee_8021q_vlan = -1;        /* Use 802.1Q VLAN tagging if >= 0 */
+static int pkt_write_file_flag = 0;     /* Write packet to file flag */
+static int pkt_read_file_flag = 0;      /* Read packet from file flag */
+static char *pkt_filename = NULL;       /* Read/Write packet to file filename */
+static int write_pkt_to_file = 0;       /* Write packet to file for debugging */
+static int rtt_flag = 0;                /* Display round-trip time */
+static pcap_dumper_t *pcap_dump_handle = NULL; /* pcap savefile handle */
+static int plain_flag = 0;              /* Only show host information */
+static int resolve_flag = 0;            /* Resolve IP addresses to hostnames */
+unsigned int random_seed = 0;
 static unsigned retry_send = DEFAULT_RETRY_SEND; /* Number of send packet retries */
 static unsigned retry_send_interval = DEFAULT_RETRY_SEND_INTERVAL; /* Interval in seconds between send packet retries */
-static unsigned int host_limit=0;	/* Exit after n responders if nonzero */
-static format_element *format=NULL;	/* Output format linked list */
+static unsigned int host_limit = 0;     /* Exit after n responders if nonzero */
+static format_element *format = NULL;   /* Output format linked list */
 
 int
 main(int argc, char *argv[]) {
@@ -101,15 +101,15 @@ main(int argc, char *argv[]) {
    uint64_t loop_timediff;    /* Time since last packet sent in us */
    uint64_t host_timediff; /* Time since last pkt sent to this host (us) */
    struct timeval last_packet_time;     /* Time last packet was sent */
-   int req_interval;		/* Requested per-packet interval */
-   int cum_err=0;               /* Cumulative timing error */
+   int req_interval;            /* Requested per-packet interval */
+   int cum_err = 0;             /* Cumulative timing error */
    struct timeval start_time;   /* Program start time */
    struct timeval end_time;     /* Program end time */
    struct timeval elapsed_time; /* Elapsed time as timeval */
    double elapsed_seconds;      /* Elapsed time in seconds */
    int reset_cum_err;
    int pass_no = 0;
-   int first_timeout=1;
+   int first_timeout = 1;
    unsigned i;
    char errbuf[PCAP_ERRBUF_SIZE];
    struct bpf_program filter;
@@ -118,42 +118,43 @@ main(int argc, char *argv[]) {
    bpf_u_int32 localnet;
    int datalink;
    int ret_status = 0;
-   int pcap_fd;			/* Pcap file descriptor */
+   int pcap_fd;                 /* Pcap file descriptor */
    unsigned char interface_mac[ETH_ALEN];
    pcap_t *pcap_handle;		/* pcap handle */
    struct in_addr interface_ip_addr;
-/*
- *	Limit process capabilities to the minimum necessary to run this program.
- *
- *	If we have POSIX.1e capability support, this removes all capabilities
- *	from the effective set and reduces the capabilities in the permitted
- *	set to the minimum needed.
- *
- *	If we do not have capability support, then drop any SUID root privs
- *	by setting the effective user id to the real uid.
- */
+   /*
+    * Limit process capabilities to the minimum necessary to run this program.
+    *
+    * If we have POSIX.1e capability support, this removes all capabilities
+    * from the effective set and reduces the capabilities in the permitted
+    * set to the minimum needed.
+    *
+    * If we do not have capability support, then drop any SUID root privs
+    * by setting the effective user id to the real uid.
+    */
    limit_capabilities();
-/*
- *      Process options.
- */
+   /*
+    * Process options.
+    */
    process_options(argc, argv);
-/*
- *      If we're not reading from a file, and --localnet was not specified, then
- *	die if no hosts were given as command line arguments.
- */
+   /*
+    * If we're not reading from a file, and --localnet was not specified, then
+    * die if no hosts were given as command line arguments.
+    */
    if (!filename_flag && !localnet_flag)
       if ((argc - optind) < 1)
-         err_msg("ERROR: No target hosts on command line and neither --file or --localnet options given");
-/*
- *      Get program start time for statistics displayed on completion.
- */
+         err_msg("ERROR: No target hosts on command line and neither --file or "
+                 "--localnet options given");
+   /*
+    * Get program start time for statistics displayed on completion.
+    */
    Gettimeofday(&start_time);
-/*
- * Open the network device for reading with pcap, or the pcap file if we
- * have specified --readpktfromfile. If we are writing packets to a binary
- * file, then set pcap_handle to NULL as we don't need to read packets in
- * this case.
- */
+   /*
+    * Open the network device for reading with pcap, or the pcap file if we
+    * have specified --readpktfromfile. If we are writing packets to a binary
+    * file, then set pcap_handle to NULL as we don't need to read packets in
+    * this case.
+    */
    if (pkt_read_file_flag) {
       if (!(pcap_handle = pcap_open_offline(pkt_filename, errbuf)))
          err_msg("pcap_open_offline: %s", errbuf);
@@ -171,7 +172,7 @@ main(int argc, char *argv[]) {
        *
        */
       if (!if_name) {
-         if (!(if_name=my_lookupdev(errbuf))) {
+         if (!(if_name = my_lookupdev(errbuf))) {
             err_msg("my_lookupdev: %s", errbuf);
          }
       }
@@ -186,7 +187,7 @@ main(int argc, char *argv[]) {
       if ((pcap_set_timeout(pcap_handle, TO_MS)) < 0) /* Is this still needed? */
          err_msg("pcap_set_timeout: %s", pcap_geterr(pcap_handle));
       ret_status = pcap_activate(pcap_handle);
-      if (ret_status < 0) {		/* Error from pcap_activate() */
+      if (ret_status < 0) { /* Error from pcap_activate() */
          char *cp;
 
          cp = pcap_geterr(pcap_handle);
@@ -199,7 +200,7 @@ main(int argc, char *argv[]) {
          else
             err_msg("pcap_activate: %s: %s", if_name,
                     pcap_statustostr(ret_status));
-      } else if (ret_status > 0) {	/* Warning from pcap_activate() */
+      } else if (ret_status > 0) { /* Warning from pcap_activate() */
          char *cp;
 
          cp = pcap_geterr(pcap_handle);
@@ -260,8 +261,8 @@ main(int argc, char *argv[]) {
             warn_msg("WARNING: Could not obtain IP address for interface %s. "
                      "Using 0.0.0.0 for", if_name);
             warn_msg("the source address, which may not be what you want.");
-            warn_msg("Either configure %s with an IP address, or manually specify"
-                     " the address", if_name);
+            warn_msg("Either configure %s with an IP address, or manually "
+                     "specify the address", if_name);
             warn_msg("with the --arpspa option.");
          }
          memcpy(&arp_spa, &(interface_ip_addr.s_addr), sizeof(arp_spa));
@@ -269,11 +270,11 @@ main(int argc, char *argv[]) {
    } else {
       pcap_handle = NULL;
    }
-/*
- *	If we are reading data with pcap, get and display the datalink details
- */
+   /*
+    * If we are reading data with pcap, get and display the datalink details
+    */
    if (pcap_handle) {
-      if ((datalink=pcap_datalink(pcap_handle)) < 0)
+      if ((datalink = pcap_datalink(pcap_handle)) < 0)
          err_msg("pcap_datalink: %s", pcap_geterr(pcap_handle));
       if (!plain_flag) {
          if (!pkt_read_file_flag) {
@@ -291,16 +292,16 @@ main(int argc, char *argv[]) {
          warn_msg("WARNING: Unsupported datalink type");
       }
    }
-/*
- *	If we are reading from a network device, then get the associated file
- *	descriptor and configure it, determine the interface IP network and
- *	netmask, and install a pcap filter to receive only ARP responses.
- *	If we are reading from a pcap file, or writing to a binary file, just
- *	set the file descriptor to -1 to indicate that it is not associated
- *	with a network device.
- */
+   /*
+    * If we are reading from a network device, then get the associated file
+    * descriptor and configure it, determine the interface IP network and
+    * netmask, and install a pcap filter to receive only ARP responses.
+    * If we are reading from a pcap file, or writing to a binary file, just
+    * set the file descriptor to -1 to indicate that it is not associated
+    * with a network device.
+    */
    if (!pkt_read_file_flag && !pkt_write_file_flag) {
-      if ((pcap_fd=pcap_get_selectable_fd(pcap_handle)) < 0)
+      if ((pcap_fd = pcap_get_selectable_fd(pcap_handle)) < 0)
          err_msg("pcap_fileno: %s", pcap_geterr(pcap_handle));
       if ((pcap_setnonblock(pcap_handle, 1, errbuf)) < 0)
          err_msg("pcap_setnonblock: %s", errbuf);
@@ -313,11 +314,11 @@ main(int argc, char *argv[]) {
             err_msg("ERROR: pcap_lookupnet: %s", errbuf);
          }
       }
-/*
- *	The pcap filter string selects packets addressed to the ARP source
- *	address that are Ethernet-II ARP packets, 802.3 LLC/SNAP ARP packets,
- *	802.1Q tagged ARP packets or 802.1Q tagged 802.3 LLC/SNAP ARP packets.
- */
+      /*
+       * The pcap filter string selects packets addressed to the ARP source
+       * address that are Ethernet-II ARP packets, 802.3 LLC/SNAP ARP packets,
+       * 802.1Q tagged ARP packets or 802.1Q tagged 802.3 LLC/SNAP ARP packets.
+       */
       filter_string=make_message("ether dst %.2x:%.2x:%.2x:%.2x:%.2x:%.2x and "
                                  "(arp or (ether[14:4]=0xaaaa0300 and "
                                  "ether[20:2]=0x0806) or (ether[12:2]=0x8100 "
@@ -336,21 +337,21 @@ main(int argc, char *argv[]) {
       free(filter_string);
       if ((pcap_setfilter(pcap_handle, &filter)) < 0)
          err_msg("pcap_setfilter: %s", pcap_geterr(pcap_handle));
-   } else {	/* Reading packets from file */
+   } else { /* Reading packets from file */
       pcap_fd = -1;
    }
-/*
- *	Open pcap savefile is the --pcapsavefile (-W) option was specified
- */
+   /*
+    * Open pcap savefile is the --pcapsavefile (-W) option was specified
+    */
    if (pcap_savefile) {
-      if (!(pcap_dump_handle=pcap_dump_open(pcap_handle, pcap_savefile))) {
+      if (!(pcap_dump_handle = pcap_dump_open(pcap_handle, pcap_savefile))) {
          err_msg("pcap_dump_open: %s", pcap_geterr(pcap_handle));
       }
    }
-/*
- *      Check that the combination of specified options and arguments is
- *      valid.
- */
+   /*
+    * Check that the combination of specified options and arguments is
+    * valid.
+    */
    if (interval && bandwidth != DEFAULT_BANDWIDTH)
       err_msg("ERROR: You cannot specify both --bandwidth and --interval.");
    if (localnet_flag) {
@@ -359,9 +360,9 @@ main(int argc, char *argv[]) {
       if (filename_flag)
          err_msg("ERROR: You can not specify both --file and --localnet options");
    }
-/*
- * Create MAC/Vendor hash table if quiet is not in effect.
- */
+   /*
+    * Create MAC/Vendor hash table if quiet is not in effect.
+    */
    if (!quiet_flag) {
       char *fn;
       int count;
@@ -383,17 +384,17 @@ main(int argc, char *argv[]) {
                   count, fn);
       free(fn);
    }
-/*
- *      Populate the list from the specified file if --file was specified, or
- *	from the interface address and mask if --localnet was specified, or
- *      otherwise from the remaining command line arguments.
- */
+   /*
+    * Populate the list from the specified file if --file was specified, or
+    * from the interface address and mask if --localnet was specified, or
+    * otherwise from the remaining command line arguments.
+    */
    if (filename_flag) { /* Populate list from file */
       FILE *fp;
       char line[MAXLINE];
       char *cp;
 
-      if ((strcmp(filename, "-")) == 0) {       /* Filename "-" means stdin */
+      if ((strcmp(filename, "-")) == 0) { /* Filename "-" means stdin */
          fp = stdin;
       } else {
          if ((fp = fopen(filename, "r")) == NULL) {
@@ -410,7 +411,7 @@ main(int argc, char *argv[]) {
       if (fp != stdin) {
          fclose(fp);
       }
-   } else if (localnet_flag) {	/* Populate list from i/f addr & mask */
+   } else if (localnet_flag) { /* Populate list from i/f addr & mask */
       struct in_addr if_network;
       struct in_addr if_netmask;
       char *c_network;
@@ -432,49 +433,48 @@ main(int argc, char *argv[]) {
          warn_msg("Using %s for localnet", localnet_descr);
       }
       add_host_pattern(localnet_descr, timeout);
-   } else {             /* Populate list from command line arguments */
-      argv=&argv[optind];
+   } else { /* Populate list from command line arguments */
+      argv = &argv[optind];
       while (*argv) {
          add_host_pattern(*argv, timeout);
          argv++;
       }
    }
-/*
- *      Check that we have at least one entry in the list.
- */
+   /*
+    * Check that we have at least one entry in the list.
+    */
    if (!num_hosts)
       err_msg("ERROR: No hosts to process.");
-/*
- *	If --writepkttofile was specified, open the specified output file.
- */
+   /*
+    *	If --writepkttofile was specified, open the specified output file.
+    */
    if (pkt_write_file_flag) {
       write_pkt_to_file = open(pkt_filename, O_WRONLY|O_CREAT|O_TRUNC, 0666);
       if (write_pkt_to_file == -1)
          err_sys("open %s", pkt_filename);
    }
-/*
- *      Create and initialise array of pointers to host entries.
- */
+   /*
+    * Create and initialise array of pointers to host entries.
+    */
    helistptr = Malloc(num_hosts * sizeof(host_entry *));
    for (i=0; i<num_hosts; i++)
       helistptr[i] = &helist[i];
-/*
- *      Randomise the list if required.
- *	Uses Knuth's shuffle algorithm.
- */
+   /*
+    * Randomise the list if required. Uses Knuth's shuffle algorithm.
+    */
    if (random_flag) {
       int r;
       host_entry *temp;
-/*
- *      Seed random number generator.
- *      If the random seed has been specified (is non-zero), then use that.
- *      Otherwise, seed the RNG with an unpredictable value.
- */
+      /*
+       * Seed random number generator.
+       * If the random seed has been specified (is non-zero), then use that.
+       * Otherwise, seed the RNG with an unpredictable value.
+       */
       if (!random_seed) {
          struct timeval tv;
 
          Gettimeofday(&tv);
-         random_seed = tv.tv_usec ^ getpid();	/* Unpredictable value */
+         random_seed = tv.tv_usec ^ getpid(); /* Unpredictable value */
       }
       init_genrand(random_seed);
 
@@ -485,71 +485,71 @@ main(int argc, char *argv[]) {
          helistptr[r] = temp;
       }
    }
-/*
- *      Set current host pointer (cursor) to start of list, zero
- *      last packet sent time, and set last receive time to now.
- */
+   /*
+    * Set current host pointer (cursor) to start of list, zero
+    * last packet sent time, and set last receive time to now.
+    */
    live_count = num_hosts;
    cursor = helistptr;
-   last_packet_time.tv_sec=0;
-   last_packet_time.tv_usec=0;
-/*
- *      Calculate the required interval to achieve the required outgoing
- *      bandwidth unless the interval was manually specified with --interval.
- */
+   last_packet_time.tv_sec = 0;
+   last_packet_time.tv_usec = 0;
+   /*
+    * Calculate the required interval to achieve the required outgoing
+    * bandwidth unless the interval was manually specified with --interval.
+    */
    if (!interval) {
       size_t packet_out_len;
 
-      packet_out_len=send_packet(NULL, NULL, NULL); /* Get packet data size */
+      packet_out_len = send_packet(NULL, NULL, NULL); /* Get packet data size */
       if (packet_out_len < MINIMUM_FRAME_SIZE)
-         packet_out_len = MINIMUM_FRAME_SIZE;   /* Adjust to minimum size */
-      packet_out_len += PACKET_OVERHEAD;	/* Add layer 2 overhead */
+         packet_out_len = MINIMUM_FRAME_SIZE; /* Adjust to minimum size */
+      packet_out_len += PACKET_OVERHEAD; /* Add layer 2 overhead */
       interval = ((uint64_t)packet_out_len * 8 * 1000000) / bandwidth;
       if (verbose > 1) {
          warn_msg("DEBUG: pkt len=%zu bytes, bandwidth=%u bps, interval=%u us",
                   packet_out_len, bandwidth, interval);
       }
    }
-/*
- *      Display initial message.
- */
+   /*
+    * Display initial message.
+    */
    if (!plain_flag) {
       printf("Starting %s with %u hosts (https://github.com/royhills/arp-scan)\n",
           PACKAGE_STRING, num_hosts);
    }
-/*
- *      Display the lists if verbose setting is 3 or more.
- */
+   /*
+    * Display the lists if verbose setting is 3 or more.
+    */
    if (verbose > 2)
       dump_list();
-/*
- *      Main loop: send packets to all hosts in order until a response
- *      has been received or the host has exhausted its retry limit.
- *
- *      The loop exits when all hosts have either responded or timed out;
- *	or if the number of responders reaches host_limit when host_limit is
- *	non zero.
- */
+   /*
+    * Main loop: send packets to all hosts in order until a response
+    * has been received or the host has exhausted its retry limit.
+    *
+    * The loop exits when all hosts have either responded or timed out;
+    * or if the number of responders reaches host_limit when host_limit is
+    * non zero.
+    */
    reset_cum_err = 1;
    req_interval = interval;
    while (live_count && !(host_limit != 0 && responders >= host_limit)) {
-/*
- *      Obtain current time and calculate deltas since last packet and
- *      last packet to this host.
- */
+      /*
+       * Obtain current time and calculate deltas since last packet and
+       * last packet to this host.
+       */
       Gettimeofday(&now);
-/*
- *      If the last packet was sent more than interval us ago, then we can
- *      potentially send a packet to the current host.
- */
+      /*
+       * If the last packet was sent more than interval microseconds ago, we
+       * can potentially send a packet to the current host.
+       */
       timeval_diff(&now, &last_packet_time, &diff);
       loop_timediff = (uint64_t)1000000*diff.tv_sec + diff.tv_usec;
       if (loop_timediff >= (unsigned)req_interval) {
-/*
- *      If the last packet to this host was sent more than the current
- *      timeout for this host us ago, then we can potentially send a packet
- *      to it.
- */
+         /*
+          * If the last packet to this host was sent more than the current
+          * timeout for this host us ago, then we can potentially send a packet
+          * to it.
+          */
          timeval_diff(&now, &((*cursor)->last_send_time), &diff);
          host_timediff = (uint64_t)1000000*diff.tv_sec + diff.tv_usec;
          if (host_timediff >= (*cursor)->timeout) {
@@ -566,21 +566,21 @@ main(int argc, char *argv[]) {
                }
             }
             select_timeout = req_interval;
-/*
- *      If we've exceeded our retry limit, then this host has timed out so
- *      remove it from the list. Otherwise, increase the timeout by the
- *      backoff factor if this is not the first packet sent to this host
- *      and send a packet.
- */
-            if (verbose && (*cursor)->num_sent > pass_no) {
+            /*
+             * If we've exceeded our retry limit, this host has timed out so
+             * remove it from the list. Otherwise increase the timeout by the
+             * backoff factor if this is not the first packet sent to this host
+             * and send a packet.
+             */
+               if (verbose && (*cursor)->num_sent > pass_no) {
                warn_msg("---\tPass %d complete", pass_no+1);
                pass_no = (*cursor)->num_sent;
             }
             if ((*cursor)->num_sent >= retry) {
                if (verbose > 1)
                   warn_msg("---\tRemoving host %s - Timeout",
-                            my_ntoa((*cursor)->addr));
-               remove_host(cursor);     /* Automatically calls advance_cursor() */
+                           my_ntoa((*cursor)->addr));
+               remove_host(cursor); /* Automatically calls advance_cursor() */
                if (first_timeout) {
                   timeval_diff(&now, &((*cursor)->last_send_time), &diff);
                   host_timediff = (uint64_t)1000000*diff.tv_sec +
@@ -598,31 +598,31 @@ main(int argc, char *argv[]) {
                      host_timediff = (uint64_t)1000000*diff.tv_sec +
                                      diff.tv_usec;
                   }
-                  first_timeout=0;
+                  first_timeout = 0;
                }
                Gettimeofday(&last_packet_time);
-            } else {    /* Retry limit not reached for this host */
+            } else { /* Retry limit not reached for this host */
                if ((*cursor)->num_sent)
                   (*cursor)->timeout *= backoff_factor;
                send_packet(pcap_handle, *cursor, &last_packet_time);
                advance_cursor();
             }
-         } else {       /* We can't send a packet to this host yet */
-/*
- *      Note that there is no point calling advance_cursor() here because if
- *      host n is not ready to send, then host n+1 will not be ready either.
- */
+         } else { /* We can't send a packet to this host yet */
+            /*
+             * There is no point calling advance_cursor() here because if
+             * host n is not ready to send host n+1 will not be ready either.
+             */
             select_timeout = (*cursor)->timeout - host_timediff;
             reset_cum_err = 1;  /* Zero cumulative error */
          } /* End If */
-      } else {          /* We can't send a packet yet */
+      } else { /* We can't send a packet yet */
          select_timeout = req_interval - loop_timediff;
       } /* End If */
       recvfrom_wto(pcap_fd, select_timeout, pcap_handle);
    } /* End While */
 
    if (!plain_flag) {
-      printf("\n");        /* Ensure we have a blank line */
+      printf("\n"); /* Ensure we have a blank line */
    }
 
    clean_up(pcap_handle);
@@ -635,14 +635,16 @@ main(int argc, char *argv[]) {
                       elapsed_time.tv_usec/1000) / 1000.0;
 
    if (!plain_flag) {
-      printf("Ending %s: %u hosts scanned in %.3f seconds (%.2f hosts/sec). %u responded\n",
+      printf("Ending %s: %u hosts scanned in %.3f seconds (%.2f hosts/sec). %u "
+             "responded\n",
              PACKAGE_STRING, num_hosts, elapsed_seconds,
              num_hosts/elapsed_seconds, responders);
    }
-/*
- * exit with status 1 if host_limit has been set with the --limit option and the
- * number of responding hosts is less than this limit. Otherwise exit with status 0.
- */
+   /*
+    * exit with status 1 if host_limit has been set with the --limit option and
+    * the number of responding hosts is less than this limit. Otherwise exit
+    * with status 0.
+    */
    return (host_limit == 0 || responders >= host_limit) ? 0 : 1;
 }
 
@@ -677,48 +679,32 @@ display_packet(host_entry *he, arp_ether_ipv4 *arpei,
       char *value;
    } field;
    static field fields[NUMFIELDS] = {
-      {"IP",NULL},
-      {"Name",NULL},
-      {"MAC",NULL},
-      {"HdrMAC",NULL},
-      {"Vendor",NULL},
-      {"Padding",NULL},
-      {"Framing",NULL},
-      {"VLAN",NULL},
-      {"Proto",NULL},
-      {"DUP",NULL},
-      {"RTT",NULL}
+      {"IP",NULL},     {"Name",NULL},    {"MAC",NULL},     {"HdrMAC",NULL},
+      {"Vendor",NULL}, {"Padding",NULL}, {"Framing",NULL}, {"VLAN",NULL},
+      {"Proto",NULL},  {"DUP",NULL},     {"RTT",NULL}
    };
    static const id_name_map fields_map[] = {
-      {0, "IP"},
-      {1, "Name"},
-      {2, "MAC"},
-      {3, "HdrMAC"},
-      {4, "Vendor"},
-      {5, "Padding"},
-      {6, "Framing"},
-      {7, "VLAN"},
-      {8, "Proto"},
-      {9, "DUP"},
-      {10, "RTT"},
-      {-1, NULL}	/* -1 marks the end of the list */
+      {0, "IP"},      {1, "Name"},   {2, "MAC"},
+      {3, "HdrMAC"},  {4, "Vendor"}, {5, "Padding"},
+      {6, "Framing"}, {7, "VLAN"},   {8, "Proto"},
+      {9, "DUP"},     {10, "RTT"},   {-1, NULL} /* -1 marks end of list */
    };
    char *msg;
    char *cp;
    char *ga_err_msg;
-   int nonzero=0;
+   int nonzero = 0;
    unsigned i;
-/*
- *	Assign output fields based on response packet and options.
- */
+   /*
+    * Assign output fields based on response packet and options.
+    */
 
-/*
- *	IP field, always present.
- */
+   /*
+    *	IP field, always present.
+    */
    fields[0].value = make_message("%s", my_ntoa(he->addr));
-/*
- *	Name field, present if --resolve option given.
- */
+   /*
+    * Name field, present if --resolve option given.
+    */
    if (resolve_flag) {
       cp = get_host_name(he->addr, &ga_err_msg);
       if (cp) {
@@ -728,17 +714,17 @@ display_packet(host_entry *he, arp_ether_ipv4 *arpei,
                   my_ntoa(he->addr), ga_err_msg);
       }
    }
-/*
- *	MAC field, always present.
- */
+   /*
+    * MAC field, always present.
+    */
    fields[2].value = make_message("%.2x:%.2x:%.2x:%.2x:%.2x:%.2x",
                       arpei->ar_sha[0], arpei->ar_sha[1],
                       arpei->ar_sha[2], arpei->ar_sha[3],
                       arpei->ar_sha[4], arpei->ar_sha[5]);
-/*
- *	HdrMAC field, present if source MAC in the ARP packet is different
- *	to source MAC in the Ethernet frame header.
- */
+   /*
+    * HdrMAC field, present if source MAC in the ARP packet is different
+    * to source MAC in the Ethernet frame header.
+    */
    if ((memcmp(arpei->ar_sha, frame_hdr->src_addr, ETH_ALEN)) != 0) {
       fields[3].value = make_message("%.2x:%.2x:%.2x:%.2x:%.2x:%.2x",
                          frame_hdr->src_addr[0], frame_hdr->src_addr[1],
@@ -746,20 +732,20 @@ display_packet(host_entry *he, arp_ether_ipv4 *arpei,
                          frame_hdr->src_addr[4], frame_hdr->src_addr[5]);
 
    }
-/*
- *	Vendor field, present if --quiet option not given
- */
+   /*
+    * Vendor field, present if --quiet option not given
+    */
    if (!quiet_flag) {
-/*
- *      Find vendor in hash table.
- *
- *      We start with more specific matches (against larger parts of the
- *      hardware address), and work towards less specific matches until
- *      we find a match or exhaust all possible matches.
- */
-      char oui_string[13];      /* Space for full hw addr plus NULL */
-      const char *vendor=NULL;
-      int oui_end=12;
+      /*
+       * Find vendor in hash table.
+       *
+       * We start with more specific matches (against larger parts of the
+       * hardware address), and work towards less specific matches until
+       * we find a match or exhaust all possible matches.
+       */
+      char oui_string[13]; /* Space for full hw addr plus NULL */
+      const char *vendor = NULL;
+      int oui_end = 12;
       ENTRY hash_query;
       ENTRY *hash_result;
 
@@ -767,7 +753,7 @@ display_packet(host_entry *he, arp_ether_ipv4 *arpei,
                arpei->ar_sha[0], arpei->ar_sha[1], arpei->ar_sha[2],
                arpei->ar_sha[3], arpei->ar_sha[4], arpei->ar_sha[5]);
       while (vendor == NULL && oui_end > 1) {
-         oui_string[oui_end] = '\0';    /* Truncate oui string */
+         oui_string[oui_end] = '\0'; /* Truncate oui string */
          hash_query.key = oui_string;
          hash_result = hsearch(hash_query, FIND);
          if (hash_result) {
@@ -785,21 +771,21 @@ display_packet(host_entry *he, arp_ether_ipv4 *arpei,
              fields[4].value = make_message("%s", "(Unknown: locally administered)");
          else
              fields[4].value = make_message("%s", "(Unknown)");
-/*
- *	Padding field, present if --quiet option not given and frame padding
- *	is non zero
- */
-/*
- *      Check that any data after the ARP packet is zero.
- *      If it is non-zero, and verbose is selected, then set the Padding
- *	field to the hex representation of the padding.
- */
+      /*
+       * Padding field, present if --quiet option not given and frame padding
+       * is non zero
+       */
+      /*
+       * Check that any data after the ARP packet is zero.
+       * If it is non-zero, and verbose is selected, then set the Padding
+       * field to the hex representation of the padding.
+       */
       if (extra_data_len > 0) {
          const unsigned char *ucp = extra_data;
 
          for (i=0; i<extra_data_len; i++) {
             if (ucp[i] != '\0') {
-               nonzero=1;
+               nonzero = 1;
                break;
             }
          }
@@ -807,96 +793,96 @@ display_packet(host_entry *he, arp_ether_ipv4 *arpei,
       if (nonzero) {
          fields[5].value = hexstring(extra_data, extra_data_len);
       }
-/*
- *      Framing field, present if the framing type is 802.2 LLC/SNAP
- */
+      /*
+       * Framing field, present if the framing type is 802.2 LLC/SNAP
+       */
       if (framing == FRAMING_LLC_SNAP) {
          fields[6].value = make_message("802.2 LLC/SNAP");
       }
-/*
- *      VLAN field, present if the packet uses 802.1Q VLAN tagging.
- */
+      /*
+       * VLAN field, present if the packet uses 802.1Q VLAN tagging.
+       */
       if (vlan_id != -1) {
          fields[7].value = make_message("%d", vlan_id);
       }
-/*
- *      Proto field, present if the ARP protocol type is not IP (0x0800)
- *      This can occur with trailer encapsulation ARP replies on 4.2BSD VAX
- */
+      /*
+       * Proto field, present if the ARP protocol type is not IP (0x0800)
+       * This can occur with trailer encapsulation ARP replies on 4.2BSD VAX
+       */
       if (ntohs(arpei->ar_pro) != 0x0800) {
          fields[8].value = make_message("0x%04x", ntohs(arpei->ar_pro));
       }
-/*
- *      DUP field, present if this is not the first response from this host.
- */
+      /*
+       * DUP field, present if this is not the first response from this host.
+       */
       if (he->num_recv > 1) {
          fields[9].value = make_message("%u", he->num_recv);
       }
-/*
- *	RTT field, present if the --rtt option is given
- */
+      /*
+       * RTT field, present if the --rtt option is given
+       */
       if (rtt_flag) {
          struct timeval rtt;
          struct timeval pcap_timestamp;
          unsigned long rtt_us; /* round-trip time in microseconds */
-/*
- * We can't pass a pointer to pcap_header->ts directly to timeval_diff
- * because it's not guaranteed to have the same size as a struct timeval.
- * E.g. OpenBSD 5.1 on amd64.
- */
+         /*
+          * We can't pass a pointer to pcap_header->ts directly to timeval_diff
+          * because it may not have the same size as a struct timeval.
+          * E.g. OpenBSD 5.1 on amd64.
+          */
          pcap_timestamp.tv_sec = pcap_header->ts.tv_sec;
          pcap_timestamp.tv_usec = pcap_header->ts.tv_usec;
          timeval_diff(&pcap_timestamp, &(he->last_send_time), &rtt);
          rtt_us = rtt.tv_sec * 1000000 + rtt.tv_usec;
          fields[10].value=make_message("%lu.%03lu", rtt_us/1000, rtt_us%1000);
       }
-   }    /* End if (!quiet_flag) */
-/*
- *	Output fields.
- */
-   if (!format) {	/* If --format option not given */
-/*
- *	Output IP field or Name field depending on whether --resolve option
- *	was given.
- */
+   } /* End if (!quiet_flag) */
+   /*
+    *	Output fields.
+    */
+   if (!format) { /* If --format option not given */
+      /*
+       * Output IP field or Name field depending on whether --resolve option
+       * was given.
+       */
       if (resolve_flag) {
          msg = make_message("%s", fields[1].value);
       } else {
          msg = make_message("%s", fields[0].value);
       }
-/*
- *	Output MAC field
- */
+      /*
+       * Output MAC field
+       */
       cp = msg;
       msg = make_message("%s\t%s", cp, fields[2].value);
       free(cp);
-/*
- *	Output HdrMAC field if present
- */
+      /*
+       * Output HdrMAC field if present
+       */
       if (fields[3].value) {
          cp = msg;
          msg = make_message("%s (%s)", cp, fields[3].value);
          free(cp);
       }
-/*
- *	Output Vendor field if present.
- */
+      /*
+       * Output Vendor field if present.
+       */
       if (fields[4].value) {
          cp = msg;
          msg = make_message("%s\t%s", cp, fields[4].value);
          free(cp);
       }
-/*
- *	Output Padding field if present and --verbose is given
- */
+      /*
+       * Output Padding field if present and --verbose is given
+       */
       if (fields[5].value && verbose) {
          cp = msg;
          msg = make_message("%s\tPadding=%s", cp, fields[5].value);
          free(cp);
       }
-/*
- *	Output Framing field if present.
- */
+      /*
+       * Output Framing field if present.
+       */
       if (fields[6].value) {
          cp = msg;
          if (framing == FRAMING_LLC_SNAP) {
@@ -904,51 +890,53 @@ display_packet(host_entry *he, arp_ether_ipv4 *arpei,
          }
          free(cp);
       }
-/*
- *	Output VLAN ID if the VLAN field is present.
- */
+      /*
+       * Output VLAN ID if the VLAN field is present.
+       */
       if (fields[7].value) {
          cp = msg;
          msg = make_message("%s (802.1Q VLAN=%s)", cp, fields[7].value);
          free(cp);
       }
-/*
- *	Output Proto field if present.
- */
+      /*
+       * Output Proto field if present.
+       */
       if (fields[8].value) {
          cp = msg;
          msg = make_message("%s (ARP Proto=%s)", cp, fields[8].value);
          free(cp);
       }
-/*
- *	Output DUP field if present.
- */
+      /*
+       * Output DUP field if present.
+       */
       if (fields[9].value) {
          cp = msg;
          msg = make_message("%s (DUP: %s)", cp, fields[9].value);
          free(cp);
       }
-/*
- *	Output RTT field if present.
- */
+      /*
+       * Output RTT field if present.
+       */
       if (fields[10].value) {
-         cp=msg;
-         msg=make_message("%s\tRTT=%s ms", cp, fields[10].value);
+         cp = msg;
+         msg = make_message("%s\tRTT=%s ms", cp, fields[10].value);
          free(cp);
       }
-   } else {	/* --format option given */
+   } else { /* --format option given */
       format_element *fmt;
       int idx;
 
-      msg=dupstr("");	/* Set msg to empty string */
+      msg = dupstr(""); /* Set msg to empty string */
       for (fmt=format; fmt; fmt=fmt->next) {
          if (fmt->type == FORMAT_FIELD) {
-            if ((idx=name_to_id(fmt->data, fields_map)) != -1 && fields[idx].value) {
+            if ((idx=name_to_id(fmt->data, fields_map)) != -1 &&
+                fields[idx].value) {
                cp = msg;
                msg = make_message("%s%*s", cp, fmt->width, fields[idx].value);
                free(cp);
-            } else {	/* Field name not found in map */
-               warn_msg("WARNING: Field ${%s} unknown or not available", fmt->data);
+            } else { /* Field name not found in map */
+               warn_msg("WARNING: Field ${%s} unknown or not available",
+                        fmt->data);
             }
          } else if (fmt->type == FORMAT_STRING) {
             cp = msg;
@@ -957,9 +945,9 @@ display_packet(host_entry *he, arp_ether_ipv4 *arpei,
          }
       }
    }
-/*
- *	Display the message on stdout.
- */
+   /*
+    *	Display the message on stdout.
+    */
    printf("%s\n", msg);
    free(msg);
 
@@ -1005,15 +993,15 @@ send_packet(pcap_t *pcap_handle, host_entry *he,
    unsigned i;
    struct timeval to;
    int n;
-/*
- *	Construct Ethernet frame header
- */
+   /*
+    * Construct Ethernet frame header
+    */
    memcpy(frame_hdr.dest_addr, target_mac, ETH_ALEN);
    memcpy(frame_hdr.src_addr, source_mac, ETH_ALEN);
    frame_hdr.frame_type = htons(eth_pro);
-/*
- *	Construct the ARP Header.
- */
+   /*
+    * Construct the ARP Header.
+    */
    memset(&arpei, '\0', sizeof(arp_ether_ipv4));
    arpei.ar_hrd = htons(arp_hrd);
    arpei.ar_pro = htons(arp_pro);
@@ -1031,51 +1019,51 @@ send_packet(pcap_t *pcap_handle, host_entry *he,
    }
    if (he)
       arpei.ar_tip = he->addr.s_addr;
-/*
- *	Copy the required data into the output buffer "buf" and set "buflen"
- *	to the number of bytes in this buffer.
- */
+   /*
+    * Copy the required data into the output buffer "buf" and set "buflen"
+    * to the number of bytes in this buffer.
+    */
    marshal_arp_pkt(buf, &frame_hdr, &arpei, &buflen, padding, padding_len);
-/*
- *	If host entry pointer is NULL, just return with the packet length.
- */
+   /*
+    * If host entry pointer is NULL, just return with the packet length.
+    */
    if (he == NULL)
       return buflen;
-/*
- *	Check that the host is live. Complain if not.
- */
+   /*
+    * Check that the host is live. Complain if not.
+    */
    if (!he->live) {
       warn_msg("***\tsend_packet called on non-live host: SHOULDN'T HAPPEN");
       return 0;
    }
-/*
- *	Update the last send times for this host.
- */
+   /*
+    * Update the last send times for this host.
+    */
    Gettimeofday(last_packet_time);
    he->last_send_time.tv_sec  = last_packet_time->tv_sec;
    he->last_send_time.tv_usec = last_packet_time->tv_usec;
    he->num_sent++;
-/*
- *	If we are using the undocumented --readpktfromfile option, don't send
- *	anything and just return with the number of bytes we would have sent.
- */
+   /*
+    * If we are using the undocumented --readpktfromfile option, don't send
+    * anything and just return with the number of bytes we would have sent.
+    */
    if (pkt_read_file_flag) {
       return buflen;
    }
-/*
- *	Send the packet.
- */
+   /*
+    * Send the packet.
+    */
    if (verbose > 1)
       warn_msg("---\tSending packet #%u to host %s tmo %d", he->num_sent,
                my_ntoa(he->addr), he->timeout);
-   if (write_pkt_to_file) {	/* Writing to file */
+   if (write_pkt_to_file) { /* Writing to file */
       nsent = write(write_pkt_to_file, buf, buflen);
-   } else {			/* Send packet to Ethernet adaptor */
+   } else { /* Send packet to Ethernet adaptor */
       to.tv_sec  = retry_send_interval/1000000;
       to.tv_usec = (retry_send_interval - 1000000*to.tv_sec);
       for (i=0; i<retry_send; i++) {
           nsent = pcap_sendpacket(pcap_handle, buf, buflen);
-          if (nsent >= 0) {	/* Successfully sent packet */
+          if (nsent >= 0) { /* Successfully sent packet */
               break;
           } else if (errno != EAGAIN) {	/* Unrecoverable error */
               err_sys("ERROR: failed to send packet");
@@ -1110,7 +1098,6 @@ send_packet(pcap_t *pcap_handle, host_entry *he,
  *
  *      This is called once after all hosts have been processed. It can be
  *      used to perform any tidying-up or statistics-displaying required.
- *      It does not have to do anything.
  */
 void
 clean_up(pcap_t *pcap_handle) {
@@ -1414,7 +1401,7 @@ add_host_pattern(const char *pattern, unsigned host_timeout) {
    unsigned long hostend;
    unsigned i;
    uint32_t x;
-   static int first_call=1;
+   static int first_call = 1;
    static regex_t iprange_pat;
    static regex_t ipslash_pat;
    static regex_t ipmask_pat;
@@ -1424,33 +1411,33 @@ add_host_pattern(const char *pattern, unsigned host_timeout) {
       "[0-9]+\\.[0-9]+\\.[0-9]+\\.[0-9]+/[0-9]+";
    static const char *ipmask_pat_str =
       "[0-9]+\\.[0-9]+\\.[0-9]+\\.[0-9]+:[0-9]+\\.[0-9]+\\.[0-9]+\\.[0-9]+";
-/*
- *	Compile regex patterns if this is the first time we've been called.
- */
+   /*
+    * Compile regex patterns if this is the first time we've been called.
+    */
    if (first_call) {
       int result;
       char *errbuf;
       size_t size;
 
       first_call = 0;
-      if ((result=regcomp(&iprange_pat, iprange_pat_str,
-                          REG_EXTENDED|REG_NOSUB))) {
+      if ((result = regcomp(&iprange_pat, iprange_pat_str,
+                            REG_EXTENDED|REG_NOSUB))) {
          size = regerror(result, &iprange_pat, NULL, 0);
          errbuf = Malloc(size);
          regerror(result, &iprange_pat, errbuf, size);
          err_msg("ERROR: cannot compile regex pattern \"%s\": %s",
                  iprange_pat_str, errbuf);
       }
-      if ((result=regcomp(&ipslash_pat, ipslash_pat_str,
-                          REG_EXTENDED|REG_NOSUB))) {
+      if ((result = regcomp(&ipslash_pat, ipslash_pat_str,
+                            REG_EXTENDED|REG_NOSUB))) {
          size = regerror(result, &ipslash_pat, NULL, 0);
          errbuf = Malloc(size);
          regerror(result, &ipslash_pat, errbuf, size);
          err_msg("ERROR: cannot compile regex pattern \"%s\": %s",
                  ipslash_pat_str, errbuf);
       }
-      if ((result=regcomp(&ipmask_pat, ipmask_pat_str,
-                          REG_EXTENDED|REG_NOSUB))) {
+      if ((result = regcomp(&ipmask_pat, ipmask_pat_str,
+                            REG_EXTENDED|REG_NOSUB))) {
          size = regerror(result, &ipmask_pat, NULL, 0);
          errbuf = Malloc(size);
          regerror(result, &ipmask_pat, errbuf, size);
@@ -1458,47 +1445,47 @@ add_host_pattern(const char *pattern, unsigned host_timeout) {
                  ipmask_pat_str, errbuf);
       }
    }
-/*
- *	Make a copy of pattern because we don't want to modify our argument.
- */
+   /*
+    * Make a copy of pattern because we don't want to modify our argument.
+    */
    patcopy = dupstr(pattern);
 
    if (!(regexec(&ipslash_pat, patcopy, 0, NULL, 0))) { /* IPnet/bits */
-/*
- *	Get IPnet and bits as integers. Perform basic error checking.
- */
-      cp=strchr(patcopy, '/');
-      *(cp++)='\0';	/* patcopy points to IPnet, cp points to bits */
+      /*
+       * Get IPnet and bits as integers. Perform basic error checking.
+       */
+      cp = strchr(patcopy, '/');
+      *(cp++) = '\0'; /* patcopy points to IPnet, cp points to bits */
       if (!(inet_aton(patcopy, &in_val)))
          err_msg("ERROR: %s is not a valid IP address", patcopy);
-      ipnet_val=ntohl(in_val.s_addr);	/* We need host byte order */
-      numbits=Strtoul(cp, 10);
+      ipnet_val = ntohl(in_val.s_addr); /* We need host byte order */
+      numbits = Strtoul(cp, 10);
       if (numbits<3 || numbits>32)
          err_msg("ERROR: Number of bits in %s must be between 3 and 32",
                  pattern);
-/*
- *	Construct 32-bit network bitmask from number of bits.
- */
-      mask=0;
+      /*
+       * Construct 32-bit network bitmask from number of bits.
+       */
+      mask = 0;
       for (i=0; i<numbits; i++)
          mask += 1 << i;
       mask = mask << (32-i);
-/*
- *	Mask off the network. Warn if the host bits were non-zero.
- */
-      network=ipnet_val & mask;
+      /*
+       * Mask off the network. Warn if the host bits were non-zero.
+       */
+      network = ipnet_val & mask;
       if (network != ipnet_val)
          warn_msg("WARNING: host part of %s is non-zero", pattern);
-/*
- *	Determine maximum and minimum host values. We include the host
- *	and broadcast.
- */
-      hoststart=0;
-      hostend=(1<<(32-numbits))-1;
-/*
- *	Calculate all host addresses in the range and feed to add_host()
- *	in dotted-quad format.
- */
+      /*
+       * Determine maximum and minimum host values including network
+       * and broadcast addresses.
+       */
+      hoststart = 0;
+      hostend = (1<<(32-numbits))-1;
+      /*
+       * Calculate all host addresses in the range and feed to add_host()
+       * in dotted-quad format.
+       */
       for (i=hoststart; i<=hostend; i++) {
          uint32_t hostip;
          int b1, b2, b3, b4;
@@ -1509,46 +1496,46 @@ add_host_pattern(const char *pattern, unsigned host_timeout) {
          b2 = (hostip & 0x00ff0000) >> 16;
          b3 = (hostip & 0x0000ff00) >> 8;
          b4 = (hostip & 0x000000ff);
-         snprintf(ipstr, sizeof(ipstr), "%d.%d.%d.%d", b1,b2,b3,b4);
+         snprintf(ipstr, sizeof(ipstr), "%d.%d.%d.%d", b1, b2, b3, b4);
          add_host(ipstr, host_timeout, 1);
       }
    } else if (!(regexec(&ipmask_pat, patcopy, 0, NULL, 0))) { /* IPnet:netmask */
-/*
- *	Get IPnet and bits as integers. Perform basic error checking.
- */
-      cp=strchr(patcopy, ':');
-      *(cp++)='\0';	/* patcopy points to IPnet, cp points to netmask */
+      /*
+       * Get IPnet and bits as integers. Perform basic error checking.
+       */
+      cp = strchr(patcopy, ':');
+      *(cp++) = '\0'; /* patcopy points to IPnet, cp points to netmask */
       if (!(inet_aton(patcopy, &in_val)))
          err_msg("ERROR: %s is not a valid IP address", patcopy);
-      ipnet_val=ntohl(in_val.s_addr);	/* We need host byte order */
+      ipnet_val = ntohl(in_val.s_addr); /* We need host byte order */
       if (!(inet_aton(cp, &mask_val)))
          err_msg("ERROR: %s is not a valid netmask", patcopy);
-      mask=ntohl(mask_val.s_addr);	/* We need host byte order */
-/*
- *	Calculate the number of bits in the network.
- */
+      mask = ntohl(mask_val.s_addr); /* We need host byte order */
+      /*
+       * Calculate the number of bits in the network.
+       */
       x = mask;
       for (numbits=0; x != 0; x>>=1) {
          if (x & 0x01) {
             numbits++;
          }
       }
-/*
- *	Mask off the network. Warn if the host bits were non-zero.
- */
-      network=ipnet_val & mask;
+      /*
+       * Mask off the network. Warn if the host bits were non-zero.
+       */
+      network = ipnet_val & mask;
       if (network != ipnet_val)
          warn_msg("WARNING: host part of %s is non-zero", pattern);
-/*
- *	Determine maximum and minimum host values. We include the host
- *	and broadcast.
- */
-      hoststart=0;
-      hostend=(1<<(32-numbits))-1;
-/*
- *	Calculate all host addresses in the range and feed to add_host()
- *	in dotted-quad format.
- */
+      /*
+       * Determine maximum and minimum host values including the network
+       * and broadcast addresses.
+       */
+      hoststart = 0;
+      hostend = (1<<(32-numbits))-1;
+      /*
+       * Calculate all host addresses in the range and feed to add_host()
+       * in dotted-quad format.
+       */
       for (i=hoststart; i<=hostend; i++) {
          uint32_t hostip;
          int b1, b2, b3, b4;
@@ -1559,25 +1546,25 @@ add_host_pattern(const char *pattern, unsigned host_timeout) {
          b2 = (hostip & 0x00ff0000) >> 16;
          b3 = (hostip & 0x0000ff00) >> 8;
          b4 = (hostip & 0x000000ff);
-         snprintf(ipstr, sizeof(ipstr), "%d.%d.%d.%d", b1,b2,b3,b4);
+         snprintf(ipstr, sizeof(ipstr), "%d.%d.%d.%d", b1, b2, b3, b4);
          add_host(ipstr, host_timeout, 1);
       }
    } else if (!(regexec(&iprange_pat, patcopy, 0, NULL, 0))) { /* IPstart-IPend */
-/*
- *	Get IPstart and IPend as integers.
- */
-      cp=strchr(patcopy, '-');
-      *(cp++)='\0';	/* patcopy points to IPstart, cp points to IPend */
+      /*
+       * Get IPstart and IPend as integers.
+       */
+      cp = strchr(patcopy, '-');
+      *(cp++) = '\0'; /* patcopy points to IPstart, cp points to IPend */
       if (!(inet_aton(patcopy, &in_val)))
          err_msg("ERROR: %s is not a valid IP address", patcopy);
-      hoststart=ntohl(in_val.s_addr);	/* We need host byte order */
+      hoststart = ntohl(in_val.s_addr); /* We need host byte order */
       if (!(inet_aton(cp, &in_val)))
          err_msg("ERROR: %s is not a valid IP address", cp);
-      hostend=ntohl(in_val.s_addr);	/* We need host byte order */
-/*
- *	Calculate all host addresses in the range and feed to add_host()
- *	in dotted-quad format.
- */
+      hostend = ntohl(in_val.s_addr); /* We need host byte order */
+      /*
+       * Calculate all host addresses in the range and feed to add_host()
+       * in dotted-quad format.
+       */
       for (i=hoststart; i<=hostend; i++) {
          int b1, b2, b3, b4;
          char ipstr[16];
@@ -1586,10 +1573,10 @@ add_host_pattern(const char *pattern, unsigned host_timeout) {
          b2 = (i & 0x00ff0000) >> 16;
          b3 = (i & 0x0000ff00) >> 8;
          b4 = (i & 0x000000ff);
-         snprintf(ipstr, sizeof(ipstr), "%d.%d.%d.%d", b1,b2,b3,b4);
+         snprintf(ipstr, sizeof(ipstr), "%d.%d.%d.%d", b1, b2, b3, b4);
          add_host(ipstr, host_timeout, 1);
       }
-   } else {	/* Single host or IP address */
+   } else { /* Single host or IP address */
       add_host(patcopy, host_timeout, numeric_flag);
    }
    free(patcopy);
@@ -1615,10 +1602,10 @@ add_host_pattern(const char *pattern, unsigned host_timeout) {
  */
 void
 add_host(const char *host_name, unsigned host_timeout, int numeric_only) {
-   struct in_addr *hp=NULL;
+   struct in_addr *hp = NULL;
    struct in_addr addr;
    host_entry *he;
-   static int num_left=0;	/* Number of free entries left */
+   static int num_left = 0; /* Number of free entries left */
    int result;
    char *ga_err_msg;
 
@@ -1639,26 +1626,26 @@ add_host(const char *host_name, unsigned host_timeout, int numeric_only) {
       }
    }
 
-   if (!num_left) {	/* No entries left, allocate some more */
+   if (!num_left) { /* No entries left, allocate some more */
       if (helist)
-         helist=Realloc(helist, (num_hosts * sizeof(host_entry)) +
-                        REALLOC_COUNT*sizeof(host_entry));
+         helist = Realloc(helist, (num_hosts * sizeof(host_entry)) +
+                          REALLOC_COUNT*sizeof(host_entry));
       else
-         helist=Malloc(REALLOC_COUNT*sizeof(host_entry));
+         helist = Malloc(REALLOC_COUNT*sizeof(host_entry));
       num_left = REALLOC_COUNT;
    }
 
-   he = helist + num_hosts;	/* Would array notation be better? */
+   he = helist + num_hosts; /* Would array notation be better? */
    num_hosts++;
    num_left--;
 
    memcpy(&(he->addr), &addr, sizeof(struct in_addr));
    he->live = 1;
-   he->timeout = host_timeout * 1000;	/* Convert from ms to us */
+   he->timeout = host_timeout * 1000; /* Convert from ms to us */
    he->num_sent = 0;
    he->num_recv = 0;
-   he->last_send_time.tv_sec=0;
-   he->last_send_time.tv_usec=0;
+   he->last_send_time.tv_sec = 0;
+   he->last_send_time.tv_usec = 0;
 }
 
 /*
@@ -1706,7 +1693,7 @@ advance_cursor(void) {
    if (live_count) {
       do {
          if (cursor == (helistptr+(num_hosts-1)))
-            cursor = helistptr;	/* Wrap round to beginning */
+            cursor = helistptr; /* Wrap round to beginning */
          else
             cursor++;
       } while (!(*cursor)->live);
@@ -1732,17 +1719,17 @@ host_entry *
 find_host(host_entry **he, struct in_addr *addr) {
    host_entry **p;
    int found = 0;
-   unsigned iterations = 0;	/* Used for debugging */
-/*
- *      Don't try to match if host ptr is NULL.
- *      This should never happen, but we check just in case.
- */
+   unsigned iterations = 0; /* Used for debugging */
+   /*
+    * Don't try to match if host ptr is NULL.
+    * This should never happen, but we check just in case.
+    */
    if (*he == NULL) {
       return NULL;
    }
-/*
- *	Try to match against our host list.
- */
+   /*
+    * Try to match against our host list.
+    */
    p = he;
 
    do {
@@ -1751,7 +1738,7 @@ find_host(host_entry **he, struct in_addr *addr) {
          found = 1;
       } else {
          if (p == helistptr) {
-            p = helistptr + (num_hosts-1);	/* Wrap round to end */
+            p = helistptr + (num_hosts-1); /* Wrap round to end */
          } else {
             p--;
          }
@@ -1797,11 +1784,11 @@ recvfrom_wto(int sock_fd, int tmo, pcap_t *pcap_handle) {
    if (n < 0) {
       err_sys("select");
    } else if (n == 0 && sock_fd >= 0) {
-      return;	/* Timeout */
+      return; /* Timeout */
    }
-/*
- * Call pcap_dispatch() to process the packet if we are reading packets.
- */
+   /*
+    * Call pcap_dispatch() to process the packet if we are reading packets.
+    */
    if (pcap_handle) {
       if ((pcap_dispatch(pcap_handle, -1, callback, NULL)) == -1)
          err_sys("pcap_dispatch: %s\n", pcap_geterr(pcap_handle));
@@ -1855,55 +1842,55 @@ callback(u_char *args ATTRIBUTE_UNUSED,
    size_t extra_data_len;
    int vlan_id;
    int framing;
-/*
- *      Check that the packet is large enough to decode.
- */
+   /*
+    * Check that the packet is large enough to decode.
+    */
    if (n < ETHER_HDR_SIZE + ARP_PKT_SIZE) {
       printf("%d byte packet too short to decode\n", n);
       return;
    }
-/*
- *	Limit packet size to the maximum Ethernet frame size we expect
- *	to avoid potential buffer overruns later.
- */
+   /*
+    * Limit packet size to the maximum Ethernet frame size we expect
+    * to avoid potential buffer overruns later.
+    */
    if (n > MAX_FRAME) {
       n = MAX_FRAME;
    }
-/*
- *	Unmarshal packet buffer into structures and determine framing type
- */
+   /*
+    * Unmarshal packet buffer into structures and determine framing type
+    */
    framing = unmarshal_arp_pkt(packet_in, n, &frame_hdr, &arpei, extra_data,
                                &extra_data_len, &vlan_id);
-/*
- *	Determine source IP address.
- */
+   /*
+    * Determine source IP address.
+    */
    source_ip.s_addr = arpei.ar_sip;
-/*
- *	We've received a response. Try to match up the packet by IP address
- *
- *	We should really start searching at the host before the cursor, as we
- *	know that the host to match cannot be the one at the cursor position
- *	because we call advance_cursor() after sending each packet. However,
- *	the time saved is minimal, and it's not worth the extra complexity.
- */
-   temp_cursor=find_host(cursor, &source_ip);
+   /*
+    * Try to match up the packet by IP address
+    *
+    * We should really start searching at the host before the cursor, as we
+    * know that the host to match cannot be the one at the cursor position
+    * because we call advance_cursor() after sending each packet. However,
+    * the time saved is minimal, and it's not worth the extra complexity.
+    */
+   temp_cursor = find_host(cursor, &source_ip);
    if (temp_cursor) {
-/*
- *	We found an IP match for the packet.
- *	Increment number of responses received for this host and increment
- *	total number of responding hosts if this is the first response for
- *	this host (i.e. it is not a duplicate response).
- */
+      /*
+       * We found an IP match for the packet.
+       * Increment number of responses received for this host and increment
+       * total number of responding hosts if this is the first response for
+       * this host (i.e. it is not a duplicate response).
+       */
       temp_cursor->num_recv++;
       if (temp_cursor->num_recv == 1)
-         responders++;	/* Increment responders if not a dup response */
+         responders++; /* Increment responders if not a dup response */
       if (verbose > 1)
          warn_msg("---\tReceived packet #%u from %s",
                   temp_cursor->num_recv, my_ntoa(source_ip));
-/*
- *	Display the packet if this is the first response for this host
- *	or if we are not ignoring duplicates.
- */
+      /*
+       * Display the packet if this is the first response for this host
+       * or if we are not ignoring duplicates.
+       */
       if ((temp_cursor->num_recv == 1 || !ignore_dups)) {
          if (pcap_dump_handle) {
             pcap_dump((unsigned char *)pcap_dump_handle, header, packet_in);
@@ -1914,18 +1901,19 @@ callback(u_char *args ATTRIBUTE_UNUSED,
       if (verbose > 1)
          warn_msg("---\tRemoving host %s - Received %d bytes",
                   my_ntoa(source_ip), n);
-/*
- *	Remove the responding host from the list if it is marked as "live".
- */
+      /*
+       * Remove the responding host from the list if it is marked as "live".
+       */
       if (temp_cursor->live)
          remove_host(&temp_cursor);
    } else {
-/*
- *	The received packet is not from an IP address in the list
- *	Issue a message to that effect and ignore the packet.
- */
+      /*
+       * The received packet is not from an IP address in the list
+       * Issue a message to that effect and ignore the packet.
+       */
       if (verbose)
-         warn_msg("---\tIgnoring %d bytes from unknown host %s", n, my_ntoa(source_ip));
+         warn_msg("---\tIgnoring %d bytes from unknown host %s", n,
+                  my_ntoa(source_ip));
    }
 }
 
@@ -1989,85 +1977,86 @@ process_options(int argc, char *argv[]) {
       {"format", required_argument, 0, 'F'},
       {0, 0, 0, 0}
    };
-/*
- * available short option characters:
- *
- * lower:       --c-e----jk--------------z
- * UPPER:       --C---G--JK---------U--X-Z
- * Digits:      0123456789
- */
+   /*
+    * available short option characters:
+    *
+    * lower:       --c-e----jk--------------z
+    * UPPER:       --C---G--JK---------U--X-Z
+    * Digits:      0123456789
+    */
    const char *short_options =
       "f:hr:Y:E:t:i:b:vVn:I:qgRNB:O:s:o:H:p:T:P:a:A:y:u:w:S:F:m:lLQ:W:DxM:dk:";
    int arg;
-   int options_index=0;
+   int options_index = 0;
 
-   while ((arg=getopt_long_only(argc, argv, short_options, long_options, &options_index)) != -1) {
+   while ((arg = getopt_long_only(argc, argv, short_options, long_options,
+                                  &options_index)) != -1) {
       switch (arg) {
          struct in_addr source_ip_address;
          int result;
 
-         case 'f':	/* --file */
-            filename=make_message("%s",optarg);
-            filename_flag=1;
+         case 'f': /* --file */
+            filename = make_message("%s", optarg);
+            filename_flag = 1;
             break;
-         case 'h':	/* --help */
+         case 'h': /* --help */
             usage();
-            break;	/* NOTREACHED */
-         case 'r':	/* --retry */
-            retry=Strtoul(optarg, 10);
+            break; /* NOTREACHED */
+         case 'r': /* --retry */
+            retry = Strtoul(optarg, 10);
             break;
-         case 'Y':	/* --retry-send */
-            retry_send=Strtoul(optarg, 10);
+         case 'Y': /* --retry-send */
+            retry_send = Strtoul(optarg, 10);
             break;
-         case 'E':	/* --retry-send-interval */
-            retry_send_interval=str_to_interval(optarg);
+         case 'E': /* --retry-send-interval */
+            retry_send_interval = str_to_interval(optarg);
             break;
-         case 't':	/* --timeout */
-            timeout=Strtoul(optarg, 10);
+         case 't': /* --timeout */
+            timeout = Strtoul(optarg, 10);
             break;
-         case 'i':	/* --interval */
-            interval=str_to_interval(optarg);
+         case 'i': /* --interval */
+            interval = str_to_interval(optarg);
             break;
-         case 'b':	/* --backoff */
-            backoff_factor=atof(optarg);
+         case 'b': /* --backoff */
+            backoff_factor = atof(optarg);
             break;
-         case 'v':	/* --verbose */
+         case 'v': /* --verbose */
             verbose++;
             break;
-         case 'V':	/* --version */
+         case 'V': /* --version */
             arp_scan_version();
             exit(EXIT_SUCCESS);
-            break;	/* NOTREACHED */
-         case 'n':	/* --snap */
-            snaplen=Strtol(optarg, 0);
+            break; /* NOTREACHED */
+         case 'n': /* --snap */
+            snaplen = Strtol(optarg, 0);
             break;
-         case 'I':	/* --interface */
+         case 'I': /* --interface */
             if_name = make_message("%s", optarg);
             break;
-         case 'q':	/* --quiet */
-            quiet_flag=1;
+         case 'q': /* --quiet */
+            quiet_flag = 1;
             break;
-         case 'g':	/* --ignoredups */
-            ignore_dups=1;
+         case 'g': /* --ignoredups */
+            ignore_dups = 1;
             break;
-         case 'R':	/* --random */
-            random_flag=1;
+         case 'R': /* --random */
+            random_flag = 1;
             break;
-         case 'N':	/* --numeric */
-            numeric_flag=1;
+         case 'N': /* --numeric */
+            numeric_flag = 1;
             break;
-         case 'B':      /* --bandwidth */
-            bandwidth=str_to_bandwidth(optarg);
+         case 'B': /* --bandwidth */
+            bandwidth = str_to_bandwidth(optarg);
             break;
-         case 'O':	/* --ouifile */
+         case 'O': /* --ouifile */
             ouifilename = make_message("%s", optarg);
             break;
-         case 'm':	/* --macfile */
+         case 'm': /* --macfile */
             macfilename = make_message("%s", optarg);
             break;
-         case 's':	/* --arpspa */
+         case 's': /* --arpspa */
             arp_spa_flag = 1;
-            if ((strcmp(optarg,"dest")) == 0) {
+            if ((strcmp(optarg, "dest")) == 0) {
                arp_spa_is_tpa = 1;
             } else {
                if ((inet_pton(AF_INET, optarg, &source_ip_address)) <= 0)
@@ -2075,93 +2064,93 @@ process_options(int argc, char *argv[]) {
                memcpy(&arp_spa, &(source_ip_address.s_addr), sizeof(arp_spa));
             }
             break;
-         case 'o':	/* --arpop */
-            arp_op=Strtol(optarg, 0);
+         case 'o': /* --arpop */
+            arp_op = Strtol(optarg, 0);
             break;
-         case 'H':	/* --arphrd */
-            arp_hrd=Strtol(optarg, 0);
+         case 'H': /* --arphrd */
+            arp_hrd = Strtol(optarg, 0);
             break;
-         case 'p':	/* --arppro */
-            arp_pro=Strtol(optarg, 0);
+         case 'p': /* --arppro */
+            arp_pro = Strtol(optarg, 0);
             break;
-         case 'T':	/* --destaddr */
+         case 'T': /* --destaddr */
             result = get_ether_addr(optarg, target_mac);
             if (result != 0)
                err_msg("Invalid target MAC address: %s", optarg);
             break;
-         case 'P':	/* --arppln */
-            arp_pln=Strtol(optarg, 0);
+         case 'P': /* --arppln */
+            arp_pln = Strtol(optarg, 0);
             break;
-         case 'a':	/* --arphln */
-            arp_hln=Strtol(optarg, 0);
+         case 'a': /* --arphln */
+            arp_hln = Strtol(optarg, 0);
             break;
-         case 'A':	/* --padding */
-            if (strlen(optarg) % 2)     /* Length is odd */
+         case 'A': /* --padding */
+            if (strlen(optarg) % 2) /* Length is odd */
                err_msg("ERROR: Length of --padding argument must be even (multiple of 2).");
-            padding=hex2data(optarg, &padding_len);
+            padding = hex2data(optarg, &padding_len);
             break;
-         case 'y':	/* --prototype */
-            eth_pro=Strtol(optarg, 0);
+         case 'y': /* --prototype */
+            eth_pro = Strtol(optarg, 0);
             break;
-         case 'u':	/* --arpsha */
+         case 'u': /* --arpsha */
             result = get_ether_addr(optarg, arp_sha);
             if (result != 0)
                err_msg("Invalid source MAC address: %s", optarg);
             arp_sha_flag = 1;
             break;
-         case 'w':	/* --arptha */
+         case 'w': /* --arptha */
             result = get_ether_addr(optarg, arp_tha);
             if (result != 0)
                err_msg("Invalid target MAC address: %s", optarg);
             break;
-         case 'S':	/* --srcaddr */
+         case 'S': /* --srcaddr */
             result = get_ether_addr(optarg, source_mac);
             if (result != 0)
                err_msg("Invalid target MAC address: %s", optarg);
             source_mac_flag = 1;
             break;
-         case 'l':	/* --localnet */
+         case 'l': /* --localnet */
             localnet_flag = 1;
             break;
-         case 'L':	/* --llc */
+         case 'L': /* --llc */
             llc_flag = 1;
             break;
-         case 'Q':	/* --vlan */
+         case 'Q': /* --vlan */
             ieee_8021q_vlan = Strtol(optarg, 0);
             break;
-         case 'W':	/* --pcapsavefile */
+         case 'W': /* --pcapsavefile */
             pcap_savefile = make_message("%s", optarg);
             break;
          case OPT_WRITEPKTTOFILE: /* --writepkttofile */
             pkt_filename = make_message("%s", optarg);
-            pkt_write_file_flag=1;
+            pkt_write_file_flag = 1;
             break;
          case OPT_READPKTFROMFILE: /* --readpktfromfile */
             pkt_filename = make_message("%s", optarg);
-            pkt_read_file_flag=1;
+            pkt_read_file_flag = 1;
             break;
-         case 'D':	/* --rtt */
+         case 'D': /* --rtt */
             rtt_flag = 1;
             break;
-         case 'x':	/* --plain */
+         case 'x': /* --plain */
             plain_flag = 1;
             break;
          case OPT_RANDOMSEED: /* --randomseed */
-            random_seed=Strtoul(optarg, 0);
+            random_seed = Strtoul(optarg, 0);
             break;
-         case 'M':	/* --limit */
+         case 'M': /* --limit */
             host_limit = Strtoul(optarg, 10);
             break;
-         case 'd':	/* --resolve */
+         case 'd': /* --resolve */
             resolve_flag = 1;
             break;
-         case 'F':	/* --format */
-            format=format_parse(optarg);
+         case 'F': /* --format */
+            format = format_parse(optarg);
             break;
-         default:	/* Unknown option */
+         default: /* Unknown option */
             err_msg("Usage: arp-scan [options] [hosts...]\n"
                     "Use \"arp-scan --help\" for detailed information on the available options.");
-            break;	/* NOTREACHED */
+            break; /* NOTREACHED */
       }
    }
 }
@@ -2180,7 +2169,7 @@ process_options(int argc, char *argv[]) {
  *	This displays the arp-scan version information.
  */
 void
-arp_scan_version (void) {
+arp_scan_version(void) {
    fprintf(stdout, "%s\n\n", PACKAGE_STRING);
    fprintf(stdout, "Copyright (C) 2005-2022 Roy Hills\n");
    fprintf(stdout, "License GPLv3+: GNU GPL version 3 or later <https://gnu.org/licenses/gpl.html>\n");
@@ -2218,14 +2207,14 @@ get_host_address(const char *name, struct in_addr *addr, char **error_msg) {
    struct sockaddr_in sa_in;
    int result;
 
-   if (addr == NULL)	/* Use static storage if no buffer specified */
+   if (addr == NULL) /* Use static storage if no buffer specified */
       addr = &ipa;
 
    memset(&hints, '\0', sizeof(hints));
    hints.ai_family = AF_INET;
 
    result = getaddrinfo(name, NULL, &hints, &res);
-   if (result != 0) {	/* Error occurred */
+   if (result != 0) { /* Error occurred */
       snprintf(err, MAXLINE, "%s", gai_strerror(result));
       *error_msg = err;
       return NULL;
@@ -2267,7 +2256,7 @@ get_host_name(const struct in_addr addr, char **error_msg) {
    sa_in.sin_addr = addr;
    result = getnameinfo((struct sockaddr *)&sa_in, sizeof(sa_in), name,
                         MAXLINE, NULL, 0, 0);
-   if (result != 0) {	/* Error occurred */
+   if (result != 0) { /* Error occurred */
       snprintf(err, MAXLINE, "%s", gai_strerror(result));
       *error_msg = err;
       return NULL;
@@ -2278,7 +2267,7 @@ get_host_name(const struct in_addr addr, char **error_msg) {
 }
 
 /*
- *	my_ntoa -- IPv6 compatible inet_ntoa replacement
+ *	my_ntoa -- inet_ntoa replacement
  *
  *	Inputs:
  *
@@ -2288,7 +2277,7 @@ get_host_name(const struct in_addr addr, char **error_msg) {
  *
  *	Pointer to the string representation of the IP address.
  *
- *	This currently only supports IPv4.
+ *	This only supports IPv4.
  */
 const char *
 my_ntoa(struct in_addr addr) {
@@ -2326,12 +2315,12 @@ marshal_arp_pkt(unsigned char *buffer, ether_hdr *frame_hdr,
    size_t packet_size;
 
    cp = buffer;
-/*
- *	Set initial packet length to the size of an Ethernet frame using
- *	Ethernet-II format plus the size of the ARP data. This may be
- *	increased later by LLC/SNAP frame format or padding after the
- *	ARP data.
- */
+   /*
+    * Set initial packet length to the size of an Ethernet frame using
+    * Ethernet-II format plus the size of the ARP data. This may be
+    * increased later by LLC/SNAP frame format or padding after the
+    * ARP data.
+    */
    packet_size = sizeof(frame_hdr->dest_addr) + sizeof(frame_hdr->src_addr) +
                  sizeof(frame_hdr->frame_type) +
                  sizeof(arp_pkt->ar_hrd) + sizeof(arp_pkt->ar_pro) +
@@ -2339,16 +2328,16 @@ marshal_arp_pkt(unsigned char *buffer, ether_hdr *frame_hdr,
                  sizeof(arp_pkt->ar_op)  + sizeof(arp_pkt->ar_sha) +
                  sizeof(arp_pkt->ar_sip) + sizeof(arp_pkt->ar_tha) +
                  sizeof(arp_pkt->ar_tip);
-/*
- *	Copy the Ethernet frame header to the buffer.
- */
+   /*
+    * Copy the Ethernet frame header to the buffer.
+    */
    memcpy(cp, &(frame_hdr->dest_addr), sizeof(frame_hdr->dest_addr));
    cp += sizeof(frame_hdr->dest_addr);
    memcpy(cp, &(frame_hdr->src_addr), sizeof(frame_hdr->src_addr));
    cp += sizeof(frame_hdr->src_addr);
-/*
- *	Add 802.1Q tag if we are using VLAN tagging
- */
+   /*
+    *	Add 802.1Q tag if we are using VLAN tagging
+    */
    if (ieee_8021q_vlan != -1) {
       uint16_t tci;
 
@@ -2358,30 +2347,30 @@ marshal_arp_pkt(unsigned char *buffer, ether_hdr *frame_hdr,
       cp += sizeof(vlan_tag);
       packet_size += sizeof(vlan_tag);
    }
-/*
- *	Add EtherType / Size field
- */
-   if (llc_flag) {	/* With 802.2 LLC framing, type field is frame size */
+   /*
+    * Add EtherType / Size field
+    */
+   if (llc_flag) { /* With 802.2 LLC framing, type field is frame size */
       uint16_t frame_size;
 
-      frame_size=htons(packet_size + sizeof(llc_snap));
+      frame_size = htons(packet_size + sizeof(llc_snap));
       memcpy(cp, &(frame_size), sizeof(frame_size));
-   } else {		/* With Ethernet-II framing, type field is ether type */
+   } else { /* With Ethernet-II framing, type field is ether type */
       memcpy(cp, &(frame_hdr->frame_type), sizeof(frame_hdr->frame_type));
    }
    cp += sizeof(frame_hdr->frame_type);
-/*
- *	Add IEEE 802.2 LLC and SNAP fields if we are using LLC frame format.
- */
+   /*
+    * Add IEEE 802.2 LLC and SNAP fields if we are using LLC frame format.
+    */
    if (llc_flag) {
       memcpy(cp, llc_snap, sizeof(llc_snap));
       memcpy(cp+6, &(frame_hdr->frame_type), sizeof(frame_hdr->frame_type));
       cp += sizeof(llc_snap);
       packet_size += sizeof(llc_snap);
    }
-/*
- *	Add the ARP data.
- */
+   /*
+    * Add the ARP data.
+    */
    memcpy(cp, &(arp_pkt->ar_hrd), sizeof(arp_pkt->ar_hrd));
    cp += sizeof(arp_pkt->ar_hrd);
    memcpy(cp, &(arp_pkt->ar_pro), sizeof(arp_pkt->ar_pro));
@@ -2400,9 +2389,9 @@ marshal_arp_pkt(unsigned char *buffer, ether_hdr *frame_hdr,
    cp += sizeof(arp_pkt->ar_tha);
    memcpy(cp, &(arp_pkt->ar_tip), sizeof(arp_pkt->ar_tip));
    cp += sizeof(arp_pkt->ar_tip);
-/*
- *	Add padding if specified
- */
+   /*
+    * Add padding if specified
+    */
    if (frame_padding != NULL) {
       size_t safe_padding_len;
 
@@ -2447,44 +2436,44 @@ unmarshal_arp_pkt(const unsigned char *buffer, size_t buf_len,
                   unsigned char *extra_data, size_t *extra_data_len,
                   int *vlan_id) {
    const unsigned char *cp;
-   int framing=FRAMING_ETHERNET_II;
+   int framing = FRAMING_ETHERNET_II;
 
    cp = buffer;
-/*
- *	Extract the Ethernet frame header data
- */
+   /*
+    * Extract the Ethernet frame header data
+    */
    memcpy(&(frame_hdr->dest_addr), cp, sizeof(frame_hdr->dest_addr));
    cp += sizeof(frame_hdr->dest_addr);
    memcpy(&(frame_hdr->src_addr), cp, sizeof(frame_hdr->src_addr));
    cp += sizeof(frame_hdr->src_addr);
-/*
- *	Check for 802.1Q VLAN tagging, indicated by a type code of
- *	0x8100 (TPID).
- */
+   /*
+    * Check for 802.1Q VLAN tagging, indicated by a type code of
+    * 0x8100 (TPID).
+    */
    if (*cp == 0x81 && *(cp+1) == 0x00) {
       uint16_t tci;
-      cp += 2;	/* Skip TPID */
+      cp += 2; /* Skip TPID */
       memcpy(&tci, cp, sizeof(tci));
-      cp += 2;	/* Skip TCI */
+      cp += 2; /* Skip TCI */
       *vlan_id = ntohs(tci);
-      *vlan_id &= 0x0fff;	/* Mask off PRI and CFI */
+      *vlan_id &= 0x0fff; /* Mask off PRI and CFI */
    } else {
       *vlan_id = -1;
    }
    memcpy(&(frame_hdr->frame_type), cp, sizeof(frame_hdr->frame_type));
    cp += sizeof(frame_hdr->frame_type);
-/*
- *	Check for an LLC header with SNAP. If this is present, the 802.2 LLC
- *	header will contain DSAP=0xAA, SSAP=0xAA, Control=0x03.
- *	If this 802.2 LLC header is present, skip it and the SNAP header
- */
+   /*
+    * Check for an LLC header with SNAP. If this is present, the 802.2 LLC
+    * header will contain DSAP=0xAA, SSAP=0xAA, Control=0x03.
+    * If this 802.2 LLC header is present, skip it and the SNAP header
+    */
    if (*cp == 0xAA && *(cp+1) == 0xAA && *(cp+2) == 0x03) {
-      cp += 8;	/* Skip eight bytes */
+      cp += 8; /* Skip eight bytes */
       framing = FRAMING_LLC_SNAP;
    }
-/*
- *	Extract the ARP packet data
- */
+   /*
+    * Extract the ARP packet data
+    */
    memcpy(&(arp_pkt->ar_hrd), cp, sizeof(arp_pkt->ar_hrd));
    cp += sizeof(arp_pkt->ar_hrd);
    memcpy(&(arp_pkt->ar_pro), cp, sizeof(arp_pkt->ar_pro));
@@ -2507,11 +2496,11 @@ unmarshal_arp_pkt(const unsigned char *buffer, size_t buf_len,
    if (extra_data != NULL) {
       int length;
 
-/*
- * buf_len will not exceed MAX_FRAME
- */
+      /*
+       * buf_len will not exceed MAX_FRAME
+       */
       length = buf_len - (cp - buffer);
-      if (length > 0) {		/* Extra data after ARP packet */
+      if (length > 0) { /* Extra data after ARP packet */
          memcpy(extra_data, cp, length);
       }
       *extra_data_len = length;
@@ -2533,8 +2522,8 @@ unmarshal_arp_pkt(const unsigned char *buffer, size_t buf_len,
  */
 int
 add_mac_vendor(const char *map_filename) {
-   static int first_call=1;
-   FILE *fp;	/* MAC/Vendor file handle */
+   static int first_call = 1;
+   FILE *fp; /* MAC/Vendor file handle */
    static const char *oui_pat_str = "([^\t]+)\t[\t ]*([^\t\r\n]+)";
    static regex_t oui_pat;
    regmatch_t pmatch[3];
@@ -2548,13 +2537,13 @@ add_mac_vendor(const char *map_filename) {
    int line_count;
    int result;
    ENTRY hash_entry;
-/*
- *	Compile the regex pattern if this is the first time we
- *	have been called.
- */
+   /*
+    * Compile the regex pattern if this is the first time we
+    * have been called.
+    */
    if (first_call) {
-      first_call=0;
-      if ((result=regcomp(&oui_pat, oui_pat_str, REG_EXTENDED))) {
+      first_call = 0;
+      if ((result = regcomp(&oui_pat, oui_pat_str, REG_EXTENDED))) {
          char *errbuf;
          size_t size;
          size = regerror(result, &oui_pat, NULL, 0);
@@ -2564,20 +2553,18 @@ add_mac_vendor(const char *map_filename) {
                  oui_pat_str, errbuf);
       }
    }
-/*
- *	Open the file.
- */
+   /*
+    * Open the file.
+    */
    if ((fp = fopen(map_filename, "r")) == NULL) {
       warn_sys("WARNING: Cannot open MAC/Vendor file %s", map_filename);
       return 0;
    }
-   line_count=0;
-/*
- *
- */
+   line_count = 0;
+
    while (fgets(line, MAXLINE, fp)) {
       if (line[0] == '#' || line[0] == '\n' || line[0] == '\r')
-         continue;	/* Skip blank lines and comments */
+         continue; /* Skip blank lines and comments */
       result = regexec(&oui_pat, line, 3, pmatch, 0);
       if (result == REG_NOMATCH || pmatch[1].rm_so < 0 || pmatch[2].rm_so < 0) {
          warn_msg("WARNING: Could not parse oui: %s", line);
@@ -2591,12 +2578,12 @@ add_mac_vendor(const char *map_filename) {
       } else {
          key_len = pmatch[1].rm_eo - pmatch[1].rm_so;
          data_len = pmatch[2].rm_eo - pmatch[2].rm_so;
-         key=Malloc(key_len+1);
-         data=Malloc(data_len+1);
-/*
- * Copy MAC address from line into key, ommitting any non-hex characters and
- * folding any lowercase alphabetic characters to uppercase.
- */
+         key = Malloc(key_len+1);
+         data = Malloc(data_len+1);
+         /*
+          * Copy MAC address from line into key, ommitting non-hex characters
+          * and folding lowercase alphabetic characters to uppercase.
+          */
          linep = line+pmatch[1].rm_so;
          keyp = key;
          while (linep != line+pmatch[1].rm_eo) {
@@ -2605,11 +2592,11 @@ add_mac_vendor(const char *map_filename) {
             linep++;
          }
          *keyp = '\0';
-/*
- * We cannot use strlcpy because the source is not guaranteed to be null
- * terminated. Therefore we use strncpy, specifying one less than the total
- * length, and manually null terminate the destination.
- */
+         /*
+          * We cannot use strlcpy because the source is not guaranteed to be
+          * null terminated. So we use strncpy, specifying one less than the
+          * total length, and manually null terminate the destination.
+          */
          strncpy(data, line+pmatch[2].rm_so, data_len);
          data[data_len] = '\0';
          hash_entry.key = key;
@@ -2652,14 +2639,14 @@ get_mac_vendor_filename(const char *specified_filename,
    int status;
    char *file_name;
 
-   if (!specified_filename) {	/* No filename specified */
+   if (!specified_filename) { /* No filename specified */
       file_name = make_message("%s", default_filename);
       status = stat(file_name, &statbuf);
       if (status == -1 && errno == ENOENT) {
          free(file_name);
          file_name = make_message("%s/%s", default_datadir, default_filename);
       }
-   } else {	/* Filename specified */
+   } else { /* Filename specified */
       file_name = make_message("%s", specified_filename);
    }
    return file_name;
@@ -2690,15 +2677,15 @@ get_source_ip(const char *interface_name, struct in_addr *ip_addr) {
       printf("pcap_findalldevs: %s\n", errbuf);
    }
 
-   device=alldevsp;
-   while (device != NULL && (strcmp(device->name,interface_name) != 0)) {
-      device=device->next;
+   device = alldevsp;
+   while (device != NULL && (strcmp(device->name, interface_name) != 0)) {
+      device = device->next;
    }
    if (device != NULL) { /* We found a device name match */
       for (addr=device->addresses; addr != NULL; addr=addr->next) {
          sa = addr->addr;
          if (sa->sa_family == AF_INET) {
-            sin = (struct sockaddr_in *) sa;
+            sin = (struct sockaddr_in *)sa;
             break;
          }
       }
@@ -2726,9 +2713,9 @@ get_source_ip(const char *interface_name, struct in_addr *ip_addr) {
          err_sys("getifaddrs");
       }
       for (ifa = ifap; ifa; ifa = ifa->ifa_next) {
-         if (ifa->ifa_addr && ifa->ifa_addr->sa_family==AF_INET &&
-             strcmp(ifa->ifa_name,interface_name) == 0) {
-            sin = (struct sockaddr_in *) ifa->ifa_addr;
+         if (ifa->ifa_addr && ifa->ifa_addr->sa_family == AF_INET &&
+             strcmp(ifa->ifa_name, interface_name) == 0) {
+            sin = (struct sockaddr_in *)ifa->ifa_addr;
             memcpy(ip_addr, &(sin->sin_addr), sizeof(*ip_addr));
             return 0;
          }
@@ -2736,6 +2723,6 @@ get_source_ip(const char *interface_name, struct in_addr *ip_addr) {
       freeifaddrs(ifap);
 #endif
    }
-/* If we reach here then we haven't found an IP address */
+   /* If we reach here then we haven't found an IP address */
    return -1;
 }

--- a/arp-scan.c
+++ b/arp-scan.c
@@ -120,7 +120,7 @@ main(int argc, char *argv[]) {
    int ret_status = 0;
    int pcap_fd;                 /* Pcap file descriptor */
    unsigned char interface_mac[ETH_ALEN];
-   pcap_t *pcap_handle;		/* pcap handle */
+   pcap_t *pcap_handle;         /* pcap handle */
    struct in_addr interface_ip_addr;
    /*
     * Limit process capabilities to the minimum necessary to run this program.
@@ -446,7 +446,7 @@ main(int argc, char *argv[]) {
    if (!num_hosts)
       err_msg("ERROR: No hosts to process.");
    /*
-    *	If --writepkttofile was specified, open the specified output file.
+    * If --writepkttofile was specified, open the specified output file.
     */
    if (pkt_write_file_flag) {
       write_pkt_to_file = open(pkt_filename, O_WRONLY|O_CREAT|O_TRUNC, 0666);
@@ -699,7 +699,7 @@ display_packet(host_entry *he, arp_ether_ipv4 *arpei,
     */
 
    /*
-    *	IP field, always present.
+    * IP field, always present.
     */
    fields[0].value = make_message("%s", my_ntoa(he->addr));
    /*
@@ -838,7 +838,7 @@ display_packet(host_entry *he, arp_ether_ipv4 *arpei,
       }
    } /* End if (!quiet_flag) */
    /*
-    *	Output fields.
+    * Output fields.
     */
    if (!format) { /* If --format option not given */
       /*
@@ -946,7 +946,7 @@ display_packet(host_entry *he, arp_ether_ipv4 *arpei,
       }
    }
    /*
-    *	Display the message on stdout.
+    * Display the message on stdout.
     */
    printf("%s\n", msg);
    free(msg);
@@ -1065,7 +1065,7 @@ send_packet(pcap_t *pcap_handle, host_entry *he,
           nsent = pcap_sendpacket(pcap_handle, buf, buflen);
           if (nsent >= 0) { /* Successfully sent packet */
               break;
-          } else if (errno != EAGAIN) {	/* Unrecoverable error */
+          } else if (errno != EAGAIN) { /* Unrecoverable error */
               err_sys("ERROR: failed to send packet");
           }
           if (retry_send_interval > 0) {
@@ -2336,7 +2336,7 @@ marshal_arp_pkt(unsigned char *buffer, ether_hdr *frame_hdr,
    memcpy(cp, &(frame_hdr->src_addr), sizeof(frame_hdr->src_addr));
    cp += sizeof(frame_hdr->src_addr);
    /*
-    *	Add 802.1Q tag if we are using VLAN tagging
+    * Add 802.1Q tag if we are using VLAN tagging
     */
    if (ieee_8021q_vlan != -1) {
       uint16_t tci;

--- a/error.c
+++ b/error.c
@@ -24,10 +24,10 @@
 
 #include "arp-scan.h"
 
-int daemon_proc;	/* Non-zero if process is a daemon */
+int daemon_proc; /* Non-zero if process is a daemon */
 
 /*
- *	Function to handle fatal system call errors.
+ * Function to handle fatal system call errors.
  */
 void
 err_sys(const char *fmt,...) {
@@ -40,7 +40,7 @@ err_sys(const char *fmt,...) {
 }
 
 /*
- *	Function to handle non-fatal system call errors.
+ * Function to handle non-fatal system call errors.
  */
 void
 warn_sys(const char *fmt,...) {
@@ -52,7 +52,7 @@ warn_sys(const char *fmt,...) {
 }
 
 /*
- *	Function to handle fatal errors not from system calls.
+ * Function to handle fatal errors not from system calls.
  */
 void
 err_msg(const char *fmt,...) {
@@ -65,7 +65,7 @@ err_msg(const char *fmt,...) {
 }
 
 /*
- *	Function to handle non-fatal errors not from system calls.
+ * Function to handle non-fatal errors not from system calls.
  */
 void
 warn_msg(const char *fmt,...) {
@@ -77,8 +77,8 @@ warn_msg(const char *fmt,...) {
 }
 
 /*
- *	General error printing function used by all the above
- *	functions.
+ * General error printing function used by all the above
+ * functions.
  */
 void
 err_print (int errnoflag, const char *fmt, va_list ap) {
@@ -98,9 +98,9 @@ err_print (int errnoflag, const char *fmt, va_list ap) {
    n = vsnprintf(NULL, 0, fmt, ap_copy);
    va_end(ap_copy);
    if (n < 0)
-      return;	/* vsnprintf output error */
+      return; /* vsnprintf output error */
 
-   size = (size_t) n + 1;	/* One extra byte for '\0' */
+   size = (size_t) n + 1; /* One extra byte for '\0' */
 
    buf = Malloc(size);
 
@@ -114,7 +114,7 @@ err_print (int errnoflag, const char *fmt, va_list ap) {
    }
    free(cp);
 
-   fflush(stdout);	/* In case stdout and stderr are the same */
+   fflush(stdout); /* In case stdout and stderr are the same */
    fputs(buf, stderr);
    fflush(stderr);
 }

--- a/format.c
+++ b/format.c
@@ -57,7 +57,8 @@ parsefield(format_element *node, const char *fmt, const char *fmtend) {
       errno = 0;
       w = strtol(ws + 1, &endptr, 0);
       if (endptr[0] != '}') {
-         err_msg("ERROR: incorrect show format: invalid character '%c' in field width", *endptr);
+         err_msg("ERROR: incorrect show format: invalid character '%c' in "
+                 "field width", *endptr);
       }
       if (w < INT_MIN || w > INT_MAX || errno == ERANGE) {
          err_msg("ERROR: incorrect show format: field width is out of range");
@@ -126,13 +127,13 @@ format_parse(const char *fmt) {
       else
          head = node = format_element_new();
 
-      if (fmt[0] == '$' && fmt[1] == '{') {	/* Field starting ${ */
-         fmtend = strchr(fmt, '}');	/* Check for closing brace */
+      if (fmt[0] == '$' && fmt[1] == '{') { /* Field starting ${ */
+         fmtend = strchr(fmt, '}');         /* Check for closing brace */
          if (!fmtend)
             err_msg("ERROR: incorrect show format: missing closing brace");
          parsefield(node, fmt + 2, fmtend - 1);
          fmt = fmtend + 1;
-      } else {	/* Not a field so presumably a string */
+      } else { /* Not a field so presumably a string */
          fmtend = fmt;
          do {
             fmtend += 1;

--- a/link-bpf.c
+++ b/link-bpf.c
@@ -67,17 +67,17 @@
 void
 get_hardware_address(const char *if_name, unsigned char hw_address[]) {
    struct if_msghdr *ifm;
-   struct sockaddr_dl *sdl=NULL;
+   struct sockaddr_dl *sdl = NULL;
    unsigned char *p;
    unsigned char *buf;
    size_t len;
-   int mib[] = { CTL_NET, PF_ROUTE, 0, AF_LINK, NET_RT_IFLIST, 0 };
-/*
- *	Use sysctl to obtain interface list.
- *	We first call sysctl with the 3rd arg set to NULL to obtain the
- *	required length, then malloc the buffer and call sysctl again to get
- *	the data.
- */
+   int mib[] = {CTL_NET, PF_ROUTE, 0, AF_LINK, NET_RT_IFLIST, 0};
+   /*
+    *	Use sysctl to obtain interface list.
+    *	We first call sysctl with the 3rd arg set to NULL to obtain the
+    *	required length, then malloc the buffer and call sysctl again to get
+    *	the data.
+    */
    if (sysctl(mib, 6, NULL, &len, NULL, 0) < 0)
       err_sys("sysctl");
 
@@ -85,10 +85,10 @@ get_hardware_address(const char *if_name, unsigned char hw_address[]) {
 
    if (sysctl(mib, 6, buf, &len, NULL, 0) < 0)
       err_sys("sysctl");
-/*
- *	Go through all the interfaces in the list until	we find the one that
- *	corresponds to the device we are using.
- */
+   /*
+    *	Go through all the interfaces in the list until	we find the one that
+    *	corresponds to the device we are using.
+    */
    for (p = buf; p < buf + len; p += ifm->ifm_msglen) {
       ifm = (struct if_msghdr *)p;
       sdl = (struct sockaddr_dl *)(ifm + 1);
@@ -104,8 +104,7 @@ get_hardware_address(const char *if_name, unsigned char hw_address[]) {
    }
 
    if (p >= buf + len)
-      err_msg("Could not get hardware address for interface %s",
-              if_name);
+      err_msg("Could not get hardware address for interface %s", if_name);
 
    memcpy(hw_address, sdl->sdl_data + sdl->sdl_nlen, ETH_ALEN);
    free(buf);

--- a/link-bpf.c
+++ b/link-bpf.c
@@ -73,10 +73,10 @@ get_hardware_address(const char *if_name, unsigned char hw_address[]) {
    size_t len;
    int mib[] = {CTL_NET, PF_ROUTE, 0, AF_LINK, NET_RT_IFLIST, 0};
    /*
-    *	Use sysctl to obtain interface list.
-    *	We first call sysctl with the 3rd arg set to NULL to obtain the
-    *	required length, then malloc the buffer and call sysctl again to get
-    *	the data.
+    * Use sysctl to obtain interface list.
+    * We first call sysctl with the 3rd arg set to NULL to obtain the
+    * required length, then malloc the buffer and call sysctl again to get
+    * the data.
     */
    if (sysctl(mib, 6, NULL, &len, NULL, 0) < 0)
       err_sys("sysctl");
@@ -86,8 +86,8 @@ get_hardware_address(const char *if_name, unsigned char hw_address[]) {
    if (sysctl(mib, 6, buf, &len, NULL, 0) < 0)
       err_sys("sysctl");
    /*
-    *	Go through all the interfaces in the list until	we find the one that
-    *	corresponds to the device we are using.
+    * Go through all the interfaces in the list until we find the one that
+    * corresponds to the device we are using.
     */
    for (p = buf; p < buf + len; p += ifm->ifm_msglen) {
       ifm = (struct if_msghdr *)p;

--- a/link-dlpi.c
+++ b/link-dlpi.c
@@ -71,8 +71,7 @@
 #define MAXDLBUF 8192*4
 
 /*
- *	Link layer handle structure for DLPI.
- *	This is typedef'ed as link_t.
+ * Link layer handle structure for DLPI.
  */
 typedef struct link_handle {
    int fd;

--- a/link-dlpi.c
+++ b/link-dlpi.c
@@ -249,7 +249,7 @@ link_open(const char *device) {
    memset(&dlp->bind_req, 0, DL_BIND_REQ_SIZE);
    dlp->bind_req.dl_primitive = DL_BIND_REQ;
 #ifdef DL_HP_RAWDLS
-   dlp->bind_req.dl_sap = 24;      /* from HP-UX DLPI programmers guide */
+   dlp->bind_req.dl_sap = 24; /* from HP-UX DLPI programmers guide */
    dlp->bind_req.dl_service_mode = DL_HP_RAWDLS;
 #else
    dlp->bind_req.dl_sap = DL_ETHER;

--- a/link-packet-socket.c
+++ b/link-packet-socket.c
@@ -40,8 +40,7 @@
 #endif
 
 /*
- *	Link layer handle structure for packet socket.
- *	This is typedef'ed as link_t.
+ * Link layer handle structure for packet socket.
  */
 typedef struct link_handle {
    int fd; /* Socket file descriptor */

--- a/link-packet-socket.c
+++ b/link-packet-socket.c
@@ -44,7 +44,7 @@
  *	This is typedef'ed as link_t.
  */
 typedef struct link_handle {
-   int fd;		/* Socket file descriptor */
+   int fd; /* Socket file descriptor */
    struct ifreq ifr;
    struct sockaddr_ll sll;
 } link_t;
@@ -117,12 +117,12 @@ get_hardware_address(const char *if_name, unsigned char hw_address[]) {
    link_t *handle;
 
    handle = link_open(if_name);
-   if(!handle) {
-       err_sys("link_open");
-       return;
+   if (!handle) {
+      err_sys("link_open");
+      return;
    }
 
-/* Obtain hardware address for specified interface */
+   /* Obtain hardware address for specified interface */
    if ((ioctl(handle->fd, SIOCGIFHWADDR, &(handle->ifr))) != 0)
       err_sys("ioctl");
 

--- a/utils.c
+++ b/utils.c
@@ -220,7 +220,7 @@ hexstring(const unsigned char *data, size_t size) {
    const unsigned char *cp;
    unsigned i;
    /*
-    *	If the input data is NULL, return an empty string.
+    * If the input data is NULL, return an empty string.
     */
    if (data == NULL) {
       result = Malloc(1);
@@ -228,7 +228,7 @@ hexstring(const unsigned char *data, size_t size) {
       return result;
    }
    /*
-    *	Create and return hex string.
+    * Create and return hex string.
     */
    result = Malloc(2*size + 1);
    cp = data;
@@ -437,9 +437,9 @@ limit_capabilities(void) {
    cap_flag_value_t cap_ok;
    cap_value_t cap_list[] = {CAP_NET_RAW};
    /*
-    *	Create a new capability state in "cap_p" containing only those
-    *	capabilities that are required by the application and are present in the
-    *	permitted capability set.
+    * Create a new capability state in "cap_p" containing only those
+    * capabilities that are required by the application and are present in the
+    * permitted capability set.
     */
    if (!(cap_cur_p = cap_get_proc()))
       err_sys("cap_get_proc()");
@@ -452,13 +452,13 @@ limit_capabilities(void) {
       cap_set_flag(cap_p, CAP_PERMITTED, sizeof(cap_list)/sizeof(cap_list[0]),
                    cap_list, CAP_SET);
    /*
-    *	Set the process capabilities to the new capability state.
+    * Set the process capabilities to the new capability state.
     */
    if (cap_set_proc(cap_p) < 0)
       err_sys("cap_set_proc()");
    /*
-    *	Permanently drop SUID but retain capability state.
-    *	We don't need root UID if we have the required capabilities.
+    * Permanently drop SUID but retain capability state.
+    * We don't need root UID if we have the required capabilities.
     */
    if (prctl(PR_SET_KEEPCAPS, 1) < 0)
       err_sys("prctl()");
@@ -467,7 +467,7 @@ limit_capabilities(void) {
    if (prctl(PR_SET_KEEPCAPS, 0) < 0)
       err_sys("prctl()");
    /*
-    *	Free temporary capability state storage.
+    * Free temporary capability state storage.
     */
    cap_free(cap_p);
    cap_free(cap_cur_p);

--- a/utils.c
+++ b/utils.c
@@ -56,14 +56,14 @@ timeval_diff(const struct timeval *a, const struct timeval *b,
 
    /* Perform the carry for the later subtraction by updating b. */
    if (a->tv_usec < temp.tv_usec) {
-     int nsec = (temp.tv_usec - a->tv_usec) / 1000000 + 1;
-     temp.tv_usec -= 1000000 * nsec;
-     temp.tv_sec += nsec;
+      int nsec = (temp.tv_usec - a->tv_usec) / 1000000 + 1;
+      temp.tv_usec -= 1000000 * nsec;
+      temp.tv_sec += nsec;
    }
    if (a->tv_usec - temp.tv_usec > 1000000) {
-     int nsec = (a->tv_usec - temp.tv_usec) / 1000000;
-     temp.tv_usec += 1000000 * nsec;
-     temp.tv_sec -= nsec;
+      int nsec = (a->tv_usec - temp.tv_usec) / 1000000;
+      temp.tv_usec += 1000000 * nsec;
+      temp.tv_sec -= nsec;
    }
 
    /* Compute the time difference
@@ -90,20 +90,19 @@ timeval_diff(const struct timeval *a, const struct timeval *b,
  *	This function is a modified version of hstr_i at www.snippets.org.
  */
 unsigned int
-hstr_i(const char *cptr)
-{
-      unsigned int i;
-      unsigned int j = 0;
-      int k;
+hstr_i(const char *cptr) {
+   unsigned int i;
+   unsigned int j = 0;
+   int k;
 
-      for (k=0; k<2; k++) {
-            i = *cptr++ - '0';
-            if (9 < i)
-                  i -= 7;
-            j <<= 4;
-            j |= (i & 0x0f);
-      }
-      return j;
+   for (k=0; k<2; k++) {
+      i = *cptr++ - '0';
+      if (9 < i)
+         i -= 7;
+      j <<= 4;
+      j |= (i & 0x0f);
+   }
+   return j;
 }
 
 /*
@@ -130,7 +129,7 @@ hex2data(const char *string, size_t *data_len) {
    unsigned i;
    size_t len;
 
-   if (strlen(string) %2 ) {	/* Length is odd */
+   if (strlen(string) % 2) { /* Length is odd */
       *data_len = 0;
       return NULL;
    }
@@ -139,7 +138,7 @@ hex2data(const char *string, size_t *data_len) {
    data = Malloc(len);
    cp = data;
    for (i=0; i<len; i++)
-      *cp++=hstr_i(&string[i*2]);
+      *cp++ = hstr_i(&string[i*2]);
    *data_len = len;
    return data;
 }
@@ -168,21 +167,21 @@ make_message(const char *fmt, ...) {
    size_t size = 0;
    char *p = NULL;
    va_list ap;
-/*
- * Determine required size for the resultant string.
-*/
+   /*
+    * Determine required size for the resultant string.
+    */
    va_start(ap, fmt);
    n = vsnprintf(p, size, fmt, ap);
    va_end(ap);
 
    if (n < 0)
-      return NULL;	/* vsnprintf output error */
+      return NULL; /* vsnprintf output error */
 
-   size = (size_t) n + 1;      /* One extra byte for '\0' */
+   size = (size_t)n + 1; /* One extra byte for '\0' */
    p = Malloc(size);
-/*
- * Print into the allocated space.
- */
+   /*
+    * Print into the allocated space.
+    */
    va_start(ap, fmt);
    n = vsnprintf(p, size, fmt, ap);
    va_end(ap);
@@ -220,17 +219,17 @@ hexstring(const unsigned char *data, size_t size) {
    char *r;
    const unsigned char *cp;
    unsigned i;
-/*
- *	If the input data is NULL, return an empty string.
- */
+   /*
+    *	If the input data is NULL, return an empty string.
+    */
    if (data == NULL) {
       result = Malloc(1);
       result[0] = '\0';
       return result;
    }
-/*
- *	Create and return hex string.
- */
+   /*
+    *	Create and return hex string.
+    */
    result = Malloc(2*size + 1);
    cp = data;
    r = result;
@@ -270,11 +269,11 @@ get_ether_addr(const char *address_string, unsigned char *ether_addr) {
 
    result = sscanf(address_string, "%x:%x:%x:%x:%x:%x",
                    &mac_b0, &mac_b1, &mac_b2, &mac_b3, &mac_b4, &mac_b5);
-   if (result !=6 ) {
+   if (result != 6) {
       result = sscanf(address_string, "%x-%x-%x-%x-%x-%x",
                       &mac_b0, &mac_b1, &mac_b2, &mac_b3, &mac_b4, &mac_b5);
    }
-   if (result !=6 ) {
+   if (result != 6) {
       return -1;
    }
    ether_addr[0] = mac_b0;
@@ -303,14 +302,14 @@ str_to_bandwidth(const char *bandwidth_string) {
    char *bandwidth_str;
    size_t bandwidth_len;
    unsigned value;
-   int multiplier=1;
+   int multiplier = 1;
    int end_char;
 
-   bandwidth_str=dupstr(bandwidth_string);	/* Writable copy */
-   bandwidth_len=strlen(bandwidth_str);
+   bandwidth_str = dupstr(bandwidth_string); /* Writable copy */
+   bandwidth_len = strlen(bandwidth_str);
    end_char = bandwidth_str[bandwidth_len-1];
-   if (!isdigit(end_char)) {	/* End character is not a digit */
-      bandwidth_str[bandwidth_len-1] = '\0';	/* Remove last character */
+   if (!isdigit(end_char)) { /* End character is not a digit */
+      bandwidth_str[bandwidth_len-1] = '\0'; /* Remove last character */
       switch (end_char) {
          case 'M':
          case 'm':
@@ -326,7 +325,7 @@ str_to_bandwidth(const char *bandwidth_string) {
             break;
       }
    }
-   value=Strtoul(bandwidth_str, 10);
+   value = Strtoul(bandwidth_str, 10);
    free(bandwidth_str);
    return multiplier * value;
 }
@@ -347,14 +346,14 @@ str_to_interval(const char *interval_string) {
    char *interval_str;
    size_t interval_len;
    unsigned value;
-   int multiplier=1000;
+   int multiplier = 1000;
    int end_char;
 
-   interval_str=dupstr(interval_string);	/* Writable copy */
-   interval_len=strlen(interval_str);
+   interval_str = dupstr(interval_string); /* Writable copy */
+   interval_len = strlen(interval_str);
    end_char = interval_str[interval_len-1];
-   if (!isdigit(end_char)) {	/* End character is not a digit */
-      interval_str[interval_len-1] = '\0';	/* Remove last character */
+   if (!isdigit(end_char)) {               /* End character is not a digit */
+      interval_str[interval_len-1] = '\0'; /* Remove last character */
       switch (end_char) {
          case 'U':
          case 'u':
@@ -370,7 +369,7 @@ str_to_interval(const char *interval_string) {
             break;
       }
    }
-   value=Strtoul(interval_str, 10);
+   value = Strtoul(interval_str, 10);
    free(interval_str);
    return multiplier * value;
 }
@@ -397,7 +396,7 @@ dupstr(const char *str) {
    char *cp;
    size_t len;
 
-   len = strlen(str) + 1;	/* Allow space for terminating NULL */
+   len = strlen(str) + 1; /* Allow space for terminating NULL */
    cp = Malloc(len);
    strlcpy(cp, str, len);
    return cp;
@@ -437,11 +436,11 @@ limit_capabilities(void) {
    cap_t cap_p;
    cap_flag_value_t cap_ok;
    cap_value_t cap_list[] = {CAP_NET_RAW};
-/*
- *	Create a new capability state in "cap_p" containing only those
- *	capabilities that are required by the application and are present in the
- *	permitted capability set.
- */
+   /*
+    *	Create a new capability state in "cap_p" containing only those
+    *	capabilities that are required by the application and are present in the
+    *	permitted capability set.
+    */
    if (!(cap_cur_p = cap_get_proc()))
       err_sys("cap_get_proc()");
    if (!(cap_p = cap_init()))
@@ -452,32 +451,32 @@ limit_capabilities(void) {
    if (cap_ok != CAP_CLEAR)
       cap_set_flag(cap_p, CAP_PERMITTED, sizeof(cap_list)/sizeof(cap_list[0]),
                    cap_list, CAP_SET);
-/*
- *	Set the process capabilities to the new capability state.
- */
+   /*
+    *	Set the process capabilities to the new capability state.
+    */
    if (cap_set_proc(cap_p) < 0)
       err_sys("cap_set_proc()");
-/*
- *	Permanently drop SUID but retain capability state.
- *	We don't need root UID if we have the required capabilities.
- */
+   /*
+    *	Permanently drop SUID but retain capability state.
+    *	We don't need root UID if we have the required capabilities.
+    */
    if (prctl(PR_SET_KEEPCAPS, 1) < 0)
       err_sys("prctl()");
    if (setuid(getuid()) < 0)
       err_sys("setuid()");
    if (prctl(PR_SET_KEEPCAPS, 0) < 0)
       err_sys("prctl()");
-/*
- *	Free temporary capability state storage.
- */
+   /*
+    *	Free temporary capability state storage.
+    */
    cap_free(cap_p);
    cap_free(cap_cur_p);
 #else
-   euid = geteuid();	/* Save effective user ID for later restore */
+   euid = geteuid(); /* Save effective user ID for later restore */
 #endif
    uid = getuid();
 #ifndef HAVE_LIBCAP
-   if (seteuid(uid))	/* Drop SUID: Set effective user ID to real user ID */
+   if (seteuid(uid)) /* Drop SUID: Set effective user ID to real user ID */
       err_sys("seteuid()");
 #endif
 }
@@ -500,7 +499,8 @@ limit_capabilities(void) {
  *	to the saved euid to enable privs or set it to the real user ID to
  *	remove root privs.
  */
-void set_capability(cap_status enable) {
+void
+set_capability(cap_status enable) {
 #ifdef HAVE_LIBCAP
    cap_t cap_p;
    cap_flag_value_t cap_ok;
@@ -512,7 +512,7 @@ void set_capability(cap_status enable) {
    cap_ok = CAP_CLEAR;
    cap_get_flag(cap_p, cap_list[0], CAP_PERMITTED, &cap_ok);
    if (cap_ok == CAP_CLEAR && enable)
-      return;	/* Cannot enable cap if it's not in the permitted set */
+      return; /* Cannot enable cap if it's not in the permitted set */
    cap_set_flag(cap_p, CAP_EFFECTIVE, sizeof(cap_list)/sizeof(cap_list[0]),
                 cap_list, enable?CAP_SET:CAP_CLEAR);
    if (cap_set_proc(cap_p) < 0)
@@ -545,12 +545,12 @@ void set_capability(cap_status enable) {
  *	user ID in a way that makes it impossible for the program to regain
  *	root privs.
  */
-void drop_capabilities(void)
-{
+void
+drop_capabilities(void) {
 #ifdef HAVE_LIBCAP
    cap_t cap;
 
-   cap = cap_init();	/* Create capability state with all flags cleared */
+   cap = cap_init(); /* Create capability state with all flags cleared */
    if (cap_set_proc(cap) < 0)
       err_sys("cap_set_proc()");
    cap_free(cap);
@@ -589,7 +589,7 @@ name_to_id(const char *name, const id_name_map map[]) {
       return -1;
 
    while (map[i].id != -1) {
-      if ((str_ccmp(name,map[i].name)) == 0) {
+      if ((str_ccmp(name, map[i].name)) == 0) {
          found = 1;
          break;
       }
@@ -620,15 +620,18 @@ name_to_id(const char *name, const id_name_map map[]) {
  *      instead because strcasecmp is not portable.
  */
 int
-str_ccmp( const char *s1, const char *s2 ) {
+str_ccmp(const char *s1, const char *s2) {
    int c1, c2;
 
-   for( ; ; s1++, s2++ ){
-      c1 = tolower( (unsigned char) *s1 );
-      c2 = tolower( (unsigned char) *s2 );
+   for (;; s1++, s2++) {
+      c1 = tolower((unsigned char)*s1);
+      c2 = tolower((unsigned char)*s2);
 
-      if( c1 > c2            )  return   1;
-      if( c1 < c2            )  return  -1;
-      if( c1 == 0 && c2 == 0 )  return   0;
+      if (c1 > c2)
+         return 1;
+      if (c1 < c2)
+         return -1;
+      if (c1 == 0 && c2 == 0)
+         return 0;
    }
 }

--- a/wrappers.c
+++ b/wrappers.c
@@ -37,7 +37,8 @@
  * We omit the timezone arg from this wrapper since it's obsolete and we never
  * use it.
  */
-int Gettimeofday(struct timeval *tv) {
+int
+Gettimeofday(struct timeval *tv) {
    int result;
 
    result = gettimeofday(tv, NULL);
@@ -48,7 +49,8 @@ int Gettimeofday(struct timeval *tv) {
    return result;
 }
 
-void *Malloc(size_t size) {
+void *
+Malloc(size_t size) {
    void *result;
 
    result = malloc(size);
@@ -59,10 +61,11 @@ void *Malloc(size_t size) {
    return result;
 }
 
-void *Realloc(void *ptr, size_t size) {
+void *
+Realloc(void *ptr, size_t size) {
    void *result;
 
-   result=realloc(ptr, size);
+   result = realloc(ptr, size);
 
    if (result == NULL)
       err_sys("realloc");
@@ -70,12 +73,13 @@ void *Realloc(void *ptr, size_t size) {
    return result;
 }
 
-unsigned long int Strtoul(const char *nptr, int base) {
+unsigned long int
+Strtoul(const char *nptr, int base) {
    char *endptr;
    unsigned long int result;
 
-   result=strtoul(nptr, &endptr, base);
-   if (endptr == nptr)	/* No digits converted */
+   result = strtoul(nptr, &endptr, base);
+   if (endptr == nptr) /* No digits converted */
       err_msg("ERROR: \"%s\" is not a valid numeric value", nptr);
    if (*endptr != '\0' && !isspace((unsigned char)*endptr))
       err_msg("ERROR: \"%s\" is not a valid numeric value", nptr);
@@ -83,12 +87,13 @@ unsigned long int Strtoul(const char *nptr, int base) {
    return result;
 }
 
-long int Strtol(const char *nptr, int base) {
+long int
+Strtol(const char *nptr, int base) {
    char *endptr;
    long int result;
 
-   result=strtol(nptr, &endptr, base);
-   if (endptr == nptr)	/* No digits converted */
+   result = strtol(nptr, &endptr, base);
+   if (endptr == nptr) /* No digits converted */
       err_msg("ERROR: \"%s\" is not a valid numeric value", nptr);
    if (*endptr != '\0' && !isspace((unsigned char)*endptr))
       err_msg("ERROR: \"%s\" is not a valid numeric value", nptr);
@@ -101,8 +106,7 @@ long int Strtol(const char *nptr, int base) {
  * in libpcap 1.9.0 and later.
  */
 char *
-my_lookupdev(char *errbuf)
-{
+my_lookupdev(char *errbuf) {
    pcap_if_t *alldevs;
 
 #ifndef IF_NAMESIZE
@@ -116,18 +120,18 @@ my_lookupdev(char *errbuf)
       return (NULL);
 
    if (alldevs == NULL || (alldevs->flags & PCAP_IF_LOOPBACK)) {
-   /*
-   * There are no devices on the list, or the first device
-   * on the list is a loopback device, which means there
-   * are no non-loopback devices on the list.  This means
-   * we can't return any device.
-   */
+      /*
+       * There are no devices on the list, or the first device
+       * on the list is a loopback device, which means there
+       * are no non-loopback devices on the list.  This means
+       * we can't return any device.
+       */
       (void)strlcpy(errbuf, "no suitable device found", PCAP_ERRBUF_SIZE);
       ret = NULL;
    } else {
-   /*
-   * Return the name of the first device on the list.
-   */
+      /*
+       * Return the name of the first device on the list.
+       */
       (void)strlcpy(device, alldevs->name, sizeof(device));
       ret = device;
    }


### PR DESCRIPTION
Standardise code formatting using `clang-format` as a guideline.

Config file:

```
BasedOnStyle: LLVM
IndentWidth: 3
AlwaysBreakAfterDefinitionReturnType: All
IndentCaseLabels: true
```
