### PR TITLE
Treat EACCES as ENOENT when opening mapping files in current directory

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,12 @@
+2023-01-14 Roy Hills <royhills@hotmail.com>
+
+	* arp-scan.c, arp-scan.1: Do not attempt to open ieee-oui.txt or
+	  mac-vendor.txt in the current directory if stat() fails with EACCES
+	  (permission denied). This can happen if the user does not have
+	  execute (search) permission in the current directory due to running
+	  a capabilities aware arp-scan build as root. Thanks to jaskij for
+	  reporting this bug.
+
 2023-01-07 Roy Hills <royhills@hotmail.com>
 
 	* arp-fingerprint, arp-fingerprint.1: Added arp-fingerprint -m option

--- a/arp-scan.1.dist
+++ b/arp-scan.1.dist
@@ -5,7 +5,7 @@
 .\" are permitted in any medium without royalty provided the copyright
 .\" notice and this notice are preserved.
 .\"
-.TH ARP-SCAN 1 "November 9, 2022"
+.TH ARP-SCAN 1 "January 14, 2023"
 .\" Please adjust this date whenever revising the man page.
 .SH NAME
 arp-scan \- Send ARP requests to target hosts and display responses
@@ -209,12 +209,12 @@ Use \fB--interface\fP to specify the interface.
 \fB--ouifile\fP=\fI<s>\fP or \fB-O \fI<s>\fR
 Use IEEE registry vendor mapping file \fI<s>\fP.
 Default is \fIieee-oui.txt\fP in the current directory.
-If that is not found \fI@PKGDATADIR@/ieee-oui.txt\fP is used.
+If that is not found or cannot be opened \fI@PKGDATADIR@/ieee-oui.txt\fP is used.
 .TP
 \fB--macfile\fP=\fI<s>\fP or \fB-m \fI<s>\fR
 Use custom vendor mapping file \fI<s>\fP.
 Default is \fImac-vendor.txt\fP in the current directory.
-If that is not found \fI@PKGSYSCONFDIR@/mac-vendor.txt\fP is used.
+If that is not found or cannot be opened \fI@PKGSYSCONFDIR@/mac-vendor.txt\fP is used.
 .SS "Output Format Control"
 .TP
 .BR --quiet " or " -q

--- a/arp-scan.c
+++ b/arp-scan.c
@@ -2642,7 +2642,7 @@ get_mac_vendor_filename(const char *specified_filename,
    if (!specified_filename) { /* No filename specified */
       file_name = make_message("%s", default_filename);
       status = stat(file_name, &statbuf);
-      if (status == -1 && errno == ENOENT) {
+      if (status == -1 && (errno == ENOENT || errno == EACCES)) {
          free(file_name);
          file_name = make_message("%s/%s", default_datadir, default_filename);
       }


### PR DESCRIPTION
When a capabilities aware build of `arp-scan` runs as root, it loses all root's special permissions (apart from briefly possessing the CAP_NET_RAW capability which is irrelevant for this change) and becomes an unprivileged process with UID 0.  This can cause the speculative open of `ieee-oui.txt` and `mac-vendor.txt` in the current directory to fail with `EACCES` if UID 0 lacks execute permission.

This change causes an `EACCES` (Permission Denied) to be treated as if the file were not present, causing arp-scan to load the system file (e.g. `/usr/share/arp-scan/ieee-oui.txt`) instead.

Issue: https://github.com/royhills/arp-scan/issues/119
