### PR TITLE
Add "-git" to version number to indicate development version

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,12 @@
 2023-01-14 Roy Hills <royhills@hotmail.com>
 
+	* configure.ac: Change version number from 10.0.1 to 10.0.1-git.
+	  From now on development versions will have "-git" appended to the
+	  version number. So 10.0.0 is a release version, 10.0.1-git is the
+	  development version, and 10.0.1 will be the next release version.
+
+2023-01-14 Roy Hills <royhills@hotmail.com>
+
 	* arp-scan.c, arp-scan.1: Do not attempt to open ieee-oui.txt or
 	  mac-vendor.txt in the current directory if stat() fails with EACCES
 	  (permission denied). This can happen if the user does not have

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,24 @@
 **This file gives a brief overview of the major changes between each arp-scan
 release.  For more details please read the ChangeLog file.**
 
+# 2023-01-15 arp-scan 1.10.1-git (in development)
+
+* New Features:
+
+  - New `-m` option for `arp-fingerprint` to display the host MAC addresses.
+
+* Fixed bugs:
+
+  - Fall back to system mapping files if the user lacks execute permission for
+    the current directory.
+
+* General improvements:
+
+  - `get-oui` now displays the underlying system error if the download fails
+    instead of a generic "download failed" message.
+
+  - Version numbers now have `-git` appended for development versions.
+
 # 2022-12-10 arp-scan 1.10.0 (git tag 1.10.0)
 
 ## New Features

--- a/configure.ac
+++ b/configure.ac
@@ -1,6 +1,6 @@
 dnl Process this file with autoconf to produce a configure script.
 
-AC_INIT([arp-scan],[1.10.1],[https://github.com/royhills/arp-scan])
+AC_INIT([arp-scan],[1.10.1-git],[https://github.com/royhills/arp-scan])
 AC_PREREQ([2.69])
 AC_CONFIG_SRCDIR([arp-scan.c])
 AC_CONFIG_AUX_DIR([build-aux])


### PR DESCRIPTION
Add "-git" to development versions to indicate that it's not a release version.

From this point, version numbers will change like this:

```
10.0.0     Release version
10.0.1-git Development version
10.0.1     Release version
```
