### PR TITLE
Use assert statements for things that should never happen

### DIFF
--- a/arp-scan.h
+++ b/arp-scan.h
@@ -35,6 +35,7 @@
 #include <stdarg.h>
 #include <errno.h>
 #include <limits.h>
+#include <assert.h>
 
 #include <sys/types.h>
 

--- a/utils.c
+++ b/utils.c
@@ -129,10 +129,7 @@ hex2data(const char *string, size_t *data_len) {
    unsigned i;
    size_t len;
 
-   if (strlen(string) % 2) { /* Length is odd */
-      *data_len = 0;
-      return NULL;
-   }
+   assert(strlen(string) % 2 == 0);	/* Length must be even */
 
    len = strlen(string) / 2;
    data = Malloc(len);
@@ -579,8 +576,7 @@ name_to_id(const char *name, const id_name_map map[]) {
    int found = 0;
    int i = 0;
 
-   if (map == NULL)
-      return -1;
+   assert (map != NULL);
 
    while (map[i].id != -1) {
       if ((str_ccmp(name, map[i].name)) == 0) {

--- a/utils.c
+++ b/utils.c
@@ -207,6 +207,8 @@ make_message(const char *fmt, ...) {
  *	in the output string.  Therefore the output string will be twice
  *	as long as the input data plus one extra byte for the trailing NULL.
  *
+ *	The input data "string" must not be NULL.
+ *
  *	The pointer returned points to malloc'ed storage which should be
  *	free'ed by the caller when it's no longer needed.
  */
@@ -216,11 +218,8 @@ hexstring(const unsigned char *data, size_t size) {
    char *r;
    const unsigned char *cp;
    unsigned i;
-   /*
-    * If the input data is NULL, return an empty string.
-    */
-   if (data == NULL)
-      return dupstr("");
+
+   assert (data != NULL);	/* Input data must not be NULL */
    /*
     * Create and return hex string.
     */


### PR DESCRIPTION
Use assert statements for things that should never happen.

I think the last "Shouldn't happen" error was closed off about a year ago in https://github.com/royhills/arp-scan/issues/67 (thanks @mrquincle).

So these things and other "this won't ever happen" checks will be replaced by assert() statements with this pull request.  I'm fairly confident that these conditions really won't happen now, and the use of assert() should encourage the submission of bug reports if any of them do actually happen. NDEBUG is left undefined.