### PR TITLE
Remove switch break statements when the previous statement obviously won't return

### DIFF
--- a/arp-scan.c
+++ b/arp-scan.c
@@ -2028,7 +2028,6 @@ process_options(int argc, char *argv[]) {
          case 'V': /* --version */
             arp_scan_version();
             exit(EXIT_SUCCESS);
-            break; /* NOTREACHED */
          case 'n': /* --snap */
             snaplen = Strtol(optarg, 0);
             break;
@@ -2152,8 +2151,7 @@ process_options(int argc, char *argv[]) {
          default: /* Unknown option */
             err_msg("Usage: arp-scan [options] [hosts...]\n"
                     "Use \"arp-scan --help\" for detailed information on "
-                    "the available options.");
-            break; /* NOTREACHED */
+                    "the available options.");	/* Never returns */
       }
    }
 }

--- a/utils.c
+++ b/utils.c
@@ -311,8 +311,7 @@ str_to_bandwidth(const char *bandwidth_string) {
             break;
          default:
             err_msg("ERROR: Unknown bandwidth multiplier character: \"%c\"",
-                    end_char);
-            break; /* NOTREACHED */
+                    end_char);	/* Never returns */
       }
    }
    value = Strtoul(bandwidth_str, 10);
@@ -355,8 +354,7 @@ str_to_interval(const char *interval_string) {
             break;
          default:
             err_msg("ERROR: Unknown interval multiplier character: \"%c\"",
-                    end_char);
-            break; /* NOTREACHED */
+                    end_char);	/* Never returns */
       }
    }
    value = Strtoul(interval_str, 10);


### PR DESCRIPTION
Remove switch break statements when the previous statement obviously won't return.

The statements removed should be obvious to the compiler. There is one that has been left in which is obvious to me but is not obvious to gcc 12.2 (not sure who's correct tbh!).