### PR TITLE
Updated mac-vendor.txt from OpenBSD 1.10.0 ports patch

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+2023-01-26 Roy Hills <royhills@hotmail.com>
+
+	* mac-vendor.txt: Incorporate latest OpenBSD patch changes for version
+	  1.10.0 to this file.  Thanks to @sthen for the patch.
+
 2023-01-18 Roy Hills <royhills@hotmail.com>
 
 	* mac-vendor.txt: Change the naming of the VRRP protocol to

--- a/mac-vendor.txt
+++ b/mac-vendor.txt
@@ -41,12 +41,14 @@
 52:54:00	QEMU
 b0:c4:20	Bochs
 
-# From RFC 2338: 00-00-5E-00-01-{VRID}
-# OpenBSD's CARP protocol uses VRRP's MAC addresses.
+# From RFC 5798: "IPv4 case: 00-00-5E-00-01-{VRID}"
+# OpenBSD's CARP protocol uses VRRP's IPv4 MAC addresses.
 00:00:5e:00:01	VRRP/CARP (last octet is VRID/VHID)
+# From RFC 5798: "IPv6 case: 00-00-5E-00-02-{VRID}"
+00:00:5e:00:02	IPv6 VRRP (last octet is VRID)
 
 # OpenBSD ether_fakeaddr()
-FEE1BAD	OpenBSD randomly generated MAC address
+fe:e1:ba:d	OpenBSD randomly generated MAC address
 
 # Microsoft WLBS (Windows NT Load Balancing Service)
 # http://www.microsoft.com/technet/prodtechnol/acs/reskit/acrkappb.mspx


### PR DESCRIPTION
Updated contents of `mac-vendor.txt` from the OpenBSD 1.10.0 ports patch.