### PR TITLE
Check for the OpenBSD pledge(2) function and use if present.

### DIFF
--- a/arp-scan.c
+++ b/arp-scan.c
@@ -123,6 +123,19 @@ main(int argc, char *argv[]) {
    pcap_t *pcap_handle;         /* pcap handle */
    struct in_addr interface_ip_addr;
    /*
+    * If we have `pledge(2)` then restrict system operations to only those
+    * needed as the very first operation in main(). When we have completed
+    * initial setup (parsed options, opened files and sockets etc), we will
+    * call pledge() again to further reduce this set of permitted operations.
+    */
+#ifdef HAVE_PLEDGE
+   if (pledge("stdio rpath wpath cpath dpath tmppath inet mcast fattr chown "
+              "flock unix dns getpw sendfd recvfd tape tty proc exec "
+              "prot_exec settime ps vminfo id pf route wroute audio video "
+              "bpf unveil", NULL) == -1)
+      err_sys("pledge");
+#endif
+   /*
     * Limit process capabilities to the minimum necessary to run this program.
     *
     * If we have POSIX.1e capability support, this removes all capabilities

--- a/arp-scan.c
+++ b/arp-scan.c
@@ -123,19 +123,6 @@ main(int argc, char *argv[]) {
    pcap_t *pcap_handle;         /* pcap handle */
    struct in_addr interface_ip_addr;
    /*
-    * If we have `pledge(2)` then restrict system operations to only those
-    * needed as the very first operation in main(). When we have completed
-    * initial setup (parsed options, opened files and sockets etc), we will
-    * call pledge() again to further reduce this set of permitted operations.
-    */
-#ifdef HAVE_PLEDGE
-   if (pledge("stdio rpath wpath cpath dpath tmppath inet mcast fattr chown "
-              "flock unix dns getpw sendfd recvfd tape tty proc exec "
-              "prot_exec settime ps vminfo id pf route wroute audio video "
-              "bpf unveil", NULL) == -1)
-      err_sys("pledge");
-#endif
-   /*
     * Limit process capabilities to the minimum necessary to run this program.
     *
     * If we have POSIX.1e capability support, this removes all capabilities

--- a/arp-scan.c
+++ b/arp-scan.c
@@ -454,6 +454,14 @@ main(int argc, char *argv[]) {
          err_sys("open %s", pkt_filename);
    }
    /*
+    * If we have the OpenBSD pledge(2) system call, use it to restrict
+    * system operations from this point.
+    */
+#ifdef HAVE_PLEDGE
+   if (pledge("stdio dns bpf", NULL) == -1)
+      err_sys("pledge");
+#endif
+   /*
     * Create and initialise array of pointers to host entries.
     */
    helistptr = Malloc(num_hosts * sizeof(host_entry *));

--- a/configure.ac
+++ b/configure.ac
@@ -102,7 +102,7 @@ dnl Checks for library functions.
 dnl All of these are defined by POSIX
 AC_CHECK_FUNCS([malloc gethostbyname gettimeofday inet_ntoa memset select socket strerror])
 dnl These functions might not be present on all systems
-AC_CHECK_FUNCS([getifaddrs])
+AC_CHECK_FUNCS([getifaddrs pledge])
 
 dnl
 dnl Determine link-layer implementation to use based on the $host_os variable


### PR DESCRIPTION
This is based on the OpenBSD 1.10.0 ports patch. Modified slightly to check for pledge(2) in `configure.ac` and only include the pledge code if we have it.
