### PR TITLE
Add OpenBSD link-bpf patch

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -35,6 +35,7 @@ jobs:
       run: |
         sudo make install
         arp-scan -vv --localnet --limit=1
+      if: matrix.os == 'ubuntu-latest'
     - name: print info
       run: |
         uname -a

--- a/ChangeLog
+++ b/ChangeLog
@@ -10,7 +10,7 @@
 
 	* .github/workflows/c-cpp.yml, .github/workflows/code-coverage.yml:
           Added "sudo make install" and "arp-scan -vv --localnet --limit=1"
-          to Ubuntu and macOS builds and coveralls coverage run. This increases
+          to Ubuntu build and coveralls coverage run. This increases
 	  code coverage by 7.4% on Linux and makes the commit checks more
 	  robust.
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,7 +1,12 @@
 2023-01-26 Roy Hills <royhills@hotmail.com>
 
-	* mac-vendor.txt: Incorporate latest OpenBSD patch changes for version
-	  1.10.0 to this file.  Thanks to @sthen for the patch.
+	* mac-vendor.txt: Incorporate OpenBSD patch for version 1.10.0 to this
+	  file to add CARP, IPv6 VRRPv3 and OpenBSD random MAC addresses.
+	  Thanks to @sthen for the patch.
+
+	* link-bpf.c: Incorporate OpenBSD patch for version 1.10.0 to this
+	  file to skip messages with incorrect version. Thanks to @sthen for
+	  this patch.
 
 	* .github/workflows/c-cpp.yml, .github/workflows/code-coverage.yml:
           Added "sudo make install" and "arp-scan -vv --localnet --limit=1"

--- a/link-bpf.c
+++ b/link-bpf.c
@@ -91,6 +91,11 @@ get_hardware_address(const char *if_name, unsigned char hw_address[]) {
     */
    for (p = buf; p < buf + len; p += ifm->ifm_msglen) {
       ifm = (struct if_msghdr *)p;
+   /*
+    * Skip this message if the version isn't what we expect.
+    */
+      if (ifm->ifm_version != RTM_VERSION)
+         continue;
       sdl = (struct sockaddr_dl *)(ifm + 1);
 
       if (ifm->ifm_type != RTM_IFINFO || (ifm->ifm_addrs & RTA_IFP) == 0)

--- a/link-bpf.c
+++ b/link-bpf.c
@@ -94,9 +94,8 @@ get_hardware_address(const char *if_name, unsigned char hw_address[]) {
    /*
     * Skip this message if the version isn't what we expect.
     */
-      assert(ifm->ifm_version == RTM_VERSION);	// Check for macOS
- //     if (ifm->ifm_version != RTM_VERSION)
- //        continue;
+      if (ifm->ifm_version != RTM_VERSION)
+         continue;
       sdl = (struct sockaddr_dl *)(ifm + 1);
 
       if (ifm->ifm_type != RTM_IFINFO || (ifm->ifm_addrs & RTA_IFP) == 0)

--- a/link-bpf.c
+++ b/link-bpf.c
@@ -94,8 +94,9 @@ get_hardware_address(const char *if_name, unsigned char hw_address[]) {
    /*
     * Skip this message if the version isn't what we expect.
     */
-      if (ifm->ifm_version != RTM_VERSION)
-         continue;
+      assert(ifm->ifm_version == RTM_VERSION);	// Check for macOS
+ //     if (ifm->ifm_version != RTM_VERSION)
+ //        continue;
       sdl = (struct sockaddr_dl *)(ifm + 1);
 
       if (ifm->ifm_type != RTM_IFINFO || (ifm->ifm_addrs & RTA_IFP) == 0)


### PR DESCRIPTION
Add the `link-bpf.c` patch from the OpenBSD 1.10.0 port. This should be applicable to all BPF users (OpenBSD, NetBSD, FreeBSD, DragonflyBSD, macOS).