### PR TITLE
Display OpenBSD pledge(2) support in version output

### DIFF
--- a/arp-scan.c
+++ b/arp-scan.c
@@ -2184,6 +2184,9 @@ arp_scan_version(void) {
 #ifdef HAVE_LIBCAP
    printf("Built with libcap POSIX.1e capability support.\n");
 #endif
+#ifdef HAVE_PLEDGE
+   printf("Built with OpenBSD pledge(2) support.\n");
+#endif
 }
 
 /*


### PR DESCRIPTION
Include `Built with OpenBSD pledge(2) support.` in the `arp-scan --version` output if applicable.
