### PR TITLE
Use github wiki URL in arp-scan documentation

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,9 @@
+2023-02-02 Roy Hills <royhills@hotmail.com>
+
+	* README.md, arp-fingerprint.1, arp-scan.1.dist, mac-vendor.txt:
+	  Updated references to the arp-scan wiki URL to use the github
+	  wiki at https://github.com/royhills/arp-scan/wiki.
+
 2023-01-28 Roy Hills <royhills@hotmail.com>
 
 	* arp-scan.c, configure.ac: Call pledge(2) to force the process into

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,7 @@
 **This file gives a brief overview of the major changes between each arp-scan
 release.  For more details please read the ChangeLog file.**
 
-# 2023-02-04 arp-scan 1.10.1-git (in development)
+# 2023-02-09 arp-scan 1.10.1-git (in development)
 
 * New Features:
 
@@ -10,19 +10,20 @@ release.  For more details please read the ChangeLog file.**
     setup is complete. `arp-scan --version` output includes `Built with
     OpenBSD pledge(2) support` if applicable.
 
-* Fixed bugs:
+* Fixed Bugs:
 
   - Fall back to system mapping files if user lacks execute permission in
     current directory.
   - Add `pcap_freecode()` to free BPF program memory when no longer needed.
-  - Do not enable promiscuous mode on the network interface.
+  - Do not enable promiscuous mode on the network interface as it is not needed.
 
-* General improvements:
+* General Improvements and Changes:
 
   - `get-oui` displays the underlying system error if the download fails
     instead of a generic "download failed" message.
   - CARP and IPv6 VRRP addresses added to mac-vendor.txt.
   - Version numbers have `-git` appended for development versions.
+  - Move `arp-scan` wiki from aws hosted mediawiki to github wiki.
 
 # 2022-12-10 arp-scan 1.10.0 (git tag 1.10.0)
 

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ For usage information use:
 
 For detailed information, see the manual pages: `arp-scan(1)`, `arp-fingerprint(1)`, `get-oui(1)` and `mac-vendor(5)`.
 
-See the arp-scan wiki at http://www.royhills.co.uk/wiki/ (it's a bit outdated now, but I plan to update it soon).
+See the arp-scan wiki at [https://github.com/royhills/arp-scan/wiki](https://github.com/royhills/arp-scan/wiki)
 
 # Notes for Contributors
 

--- a/arp-fingerprint.1
+++ b/arp-fingerprint.1
@@ -114,5 +114,5 @@ your system to use it.
 .TP
 .BR arp-scan (1)
 .PP
-.I http://www.royhills.co.uk/wiki/
+.I https://github.com/royhills/arp-scan/wiki
 The arp-scan wiki page.

--- a/arp-scan.1.dist
+++ b/arp-scan.1.dist
@@ -545,7 +545,7 @@ $ arp-scan -I eth0 --plain --format='${ip},${mac},"${vendor}"' 10.0.0.0/24
 .PP
 .BR arp-fingerprint (1)
 .PP
-.I http://www.royhills.co.uk/wiki/
+.I https://github.com/royhills/arp-scan/wiki
 The arp-scan wiki page.
 .PP
 .I https://github.com/royhills/arp-scan

--- a/mac-vendor.txt
+++ b/mac-vendor.txt
@@ -33,8 +33,7 @@
 #
 # Blank lines and lines beginning with "#" are ignored.
 #
-# Additional information is available on the arp-scan wiki at
-# http://www.royhills.co.uk/wiki
+# See the mac-vendor(5) manpage for more information.
 #
 
 # From nmap Debian bug report #369681 dated 31 May 2006


### PR DESCRIPTION
Update the links to the old MediaWiki `http://www.royhills.co.uk/wiki/` or `http://www.nta-monitor.com/wiki/` to the new github wiki pages at `https://github.com/royhills/arp-scan/wiki`.