### PR TITLE
Call pcap_freecode() to free the BPF program

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+2023-02-03 Roy Hills <royhills@hotmail.com>
+
+	* arp-scan.c: Call pcap_freecode() to free the BPF program after
+	  calling pcap_setfilter().  Thanks to @icy17 for the issue report.
+
 2023-01-28 Roy Hills <royhills@hotmail.com>
 
 	* arp-scan.c, configure.ac: Call pledge(2) to force the process into

--- a/NEWS.md
+++ b/NEWS.md
@@ -13,6 +13,7 @@ release.  For more details please read the ChangeLog file.**
 
   - Fall back to system mapping files if user lacks execute permission in
     current directory.
+  - Add `pcap_freecode()` to free BPF program memory when no longer needed.
 
 * General improvements:
 

--- a/arp-scan.c
+++ b/arp-scan.c
@@ -337,6 +337,7 @@ main(int argc, char *argv[]) {
       free(filter_string);
       if ((pcap_setfilter(pcap_handle, &filter)) < 0)
          err_msg("pcap_setfilter: %s", pcap_geterr(pcap_handle));
+      pcap_freecode(&filter);
    } else { /* Reading packets from file */
       pcap_fd = -1;
    }


### PR DESCRIPTION
Call `pcap_freecode()` to free the BPF program after calling `pcap_setfilter()`.