### PR TITLE
Disable promiscuous mode

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,9 @@
+2023-02-04 Roy Hills <royhills@hotmail.com>
+
+	* arp-scan.h: Disable promiscuous mode on the network interface.
+	  Promiscuous mode is not required to receive ARP response packets
+	  because they are unicast packets directed to the scanning host.
+
 2023-02-03 Roy Hills <royhills@hotmail.com>
 
 	* arp-scan.c: Call pcap_freecode() to free the BPF program after

--- a/NEWS.md
+++ b/NEWS.md
@@ -14,6 +14,7 @@ release.  For more details please read the ChangeLog file.**
   - Fall back to system mapping files if user lacks execute permission in
     current directory.
   - Add `pcap_freecode()` to free BPF program memory when no longer needed.
+  - Do not enable promiscuous mode on the network interface.
 
 * General improvements:
 

--- a/arp-scan.h
+++ b/arp-scan.h
@@ -145,7 +145,7 @@
 #define DEFAULT_RETRY 2                 /* Default number of retries */
 #define DEFAULT_TIMEOUT 500             /* Default per-host timeout in ms */
 #define SNAPLEN 64			/* 14 (ether) + 28 (ARP) + extra */
-#define PROMISC 1			/* Enable promiscuous mode */
+#define PROMISC 0			/* Promiscuous mode 0=off, 1=on */
 #define TO_MS 1000			/* Timeout for pcap_set_timeout() */
 #define OPTIMISE 1			/* Optimise pcap filter */
 #define ARPHRD_ETHER 1			/* Ethernet ARP type */


### PR DESCRIPTION
Disable promiscuous mode on the network interface. The interface does not need to be put into promiscuous mode to receive ARP responses.