### PR TITLE
Always warn if remove_host() is called on a non-live host

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,9 @@
+2023-02-25 Roy Hills <royhills@hotmail.com>
+
+	* arp-scan.c: Always warn if remove_host() is called on a non-live
+	  host. This should never happen since the changes detailed in
+	  github issue #67.
+
 2023-02-18 Roy Hills <royhills@hotmail.com>
 
 	* SECURITY.md: New file containing the security policy for reporting

--- a/arp-scan.c
+++ b/arp-scan.c
@@ -1677,8 +1677,7 @@ remove_host(host_entry **he) {
       if (*he == *cursor)
          advance_cursor();
    } else {
-      if (verbose > 1)
-         warn_msg("***\tremove_host called on non-live host: SHOULDN'T HAPPEN");
+      warn_msg("***\tremove_host called on non-live host: SHOULDN'T HAPPEN");
    }
 }
 

--- a/arp-scan.c
+++ b/arp-scan.c
@@ -1038,7 +1038,8 @@ send_packet(pcap_t *pcap_handle, host_entry *he,
     * Check that the host is live. Complain if not.
     */
    if (!he->live) {
-      warn_msg("***\tsend_packet called on non-live host: SHOULDN'T HAPPEN");
+      warn_msg("WARNING: Send attempt to inactive host: SHOULDN'T HAPPEN\n"
+               "         Please report to github.com/royhills/arp-scan/issues");
       return 0;
    }
    /*
@@ -1677,7 +1678,8 @@ remove_host(host_entry **he) {
       if (*he == *cursor)
          advance_cursor();
    } else {
-      warn_msg("***\tremove_host called on non-live host: SHOULDN'T HAPPEN");
+      warn_msg("WARNING: Attempt to remove inactive host: SHOULDN'T HAPPEN\n"
+               "         Please report to github.com/royhills/arp-scan/issues");
    }
 }
 


### PR DESCRIPTION
Always warn if remove_host() is called on a non-live host.  Previously a warning was only given if `--verbose` was specified.
This should never happen since the changes detailed in github issue #67, and if it does happen the user should know about it.