### PR TITLE
Change --localnet info message and always display it

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,10 @@
+2023-02-26 Roy Hills <royhills@hotmail.com>
+
+	* arp-scan.c: Change the informational message about the interface
+	  network and netmask used to generate the target list when
+	  --localnet is used, and always display this message (previously
+	  it was only displayed if --verbose was given).
+
 2023-02-25 Roy Hills <royhills@hotmail.com>
 
 	* arp-scan.c: Always warn if remove_host() is called on a non-live

--- a/NEWS.md
+++ b/NEWS.md
@@ -21,7 +21,7 @@
   - CARP and IPv6 VRRP addresses added to mac-vendor.txt.
   - Append `-git` to version number for pre release git development versions.
   - wiki moved from mediawiki to [github wiki](https://github.com/royhills/arp-scan/wiki).
-  - Self-test code coverage increased to 91.2% (see [code-coverage.yml](/.github/workflows/code-coverage.yml) for details of the code coverage tests).
+  - Self-test code coverage increased to 91.2% (see [code-coverage.yml](https://github.com/royhills/arp-scan/.github/workflows/code-coverage.yml) for details of the code coverage tests).
   - `CONTRIBUTING.md` and `SECURITY.md` files added.
   - Change message about interface network and mask used for --localnet, and don't require --verbose to display it.
   - Various minor improvements to the code and documentation.

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 **This file gives a brief overview of the major changes between each *arp-scan* release.  For more details please read the `ChangeLog` file.**
 
-# 2023-02-17 arp-scan 1.10.1-git (in development)
+# 2023-02-26 arp-scan 1.10.1-git (in development)
 
 * New Features:
 
@@ -20,9 +20,10 @@
   - `get-oui` displays the underlying system error if the download fails instead of a generic "download failed" message.
   - CARP and IPv6 VRRP addresses added to mac-vendor.txt.
   - Append `-git` to version number for pre release git development versions.
-  - *arp-scan* wiki moved from website using mediawiki to github wiki using markdown.
+  - wiki moved from mediawiki to [github wiki](https://github.com/royhills/arp-scan/wiki).
   - Self-test code coverage increased to 91.2% (see [code-coverage.yml](/.github/workflows/code-coverage.yml) for details of the code coverage tests).
   - `CONTRIBUTING.md` and `SECURITY.md` files added.
+  - Change message about interface network and mask used for --localnet, and don't require --verbose to display it.
   - Various minor improvements to the code and documentation.
 
 # 2022-12-10 arp-scan 1.10.0 (git tag 1.10.0)

--- a/NEWS.md
+++ b/NEWS.md
@@ -21,7 +21,7 @@
   - CARP and IPv6 VRRP addresses added to mac-vendor.txt.
   - Append `-git` to version number for pre release git development versions.
   - wiki moved from mediawiki to [github wiki](https://github.com/royhills/arp-scan/wiki).
-  - Self-test code coverage increased to 91.2% (see [code-coverage.yml](https://github.com/royhills/arp-scan/.github/workflows/code-coverage.yml) for details of the code coverage tests).
+  - Self-test code coverage increased to 91.2% (see [code-coverage.yml](/.github/workflows/code-coverage.yml) for details of the code coverage tests).
   - `CONTRIBUTING.md` and `SECURITY.md` files added.
   - Change message about interface network and mask used for --localnet, and don't require --verbose to display it.
   - Various minor improvements to the code and documentation.

--- a/arp-scan.c
+++ b/arp-scan.c
@@ -427,12 +427,10 @@ main(int argc, char *argv[]) {
       cp = my_ntoa(if_netmask);
       c_netmask = make_message("%s", cp);
       snprintf(localnet_descr, 32, "%s:%s", c_network, c_netmask);
+      warn_msg("Target list from interface network %s netmask %s",
+               c_network, c_netmask);
       free(c_network);
       free(c_netmask);
-
-      if (verbose) {
-         warn_msg("Using %s for localnet", localnet_descr);
-      }
       add_host_pattern(localnet_descr, timeout);
    } else { /* Populate list from command line arguments */
       argv = &argv[optind];


### PR DESCRIPTION
Change the informational message about the interface network and netmask used to generate the target list when --localnet is used, and always display this message (previously it was only displayed if --verbose was given).

Old message was: `Using 10.0.0.0:255.255.255.0 for localnet`.
New message is: `Target list from interface network 10.0.0.0 netmask 255.255.255.0`