### PR TITLE
Add ${IPnum} output field

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,10 @@
+2023-03-09 Roy Hills <royhills@hotmail.com>
+
+	* arp-scan.c, arp-scan.h, arp-scan.1.dist: Added the ${IPnum} output
+	  field, which displays the host IPv4 address as a 32-bit integer.
+	  This permits sorting by IP address using simple numeric comparison.
+	  Thanks to @gspannu for the feature request.
+
 2023-02-26 Roy Hills <royhills@hotmail.com>
 
 	* arp-scan.c: Change the informational message about the interface

--- a/NEWS.md
+++ b/NEWS.md
@@ -5,9 +5,9 @@
 * New Features:
 
   - New `-m` option for `arp-fingerprint` to display the host MAC addresses.
-  - OpenBSD: Call `pledge(2)` to enter restricted service mode once initial
-    setup is complete. `arp-scan --version` output includes `Built with
+  - OpenBSD: Call `pledge(2)` to enter restricted service mode once initial setup is complete. `arp-scan --version` output includes `Built with
     OpenBSD pledge(2) support` if applicable.
+  - New `${IPnum}` field name for the `--format` option which displays the host IP address as a 32-bit unsigned integer. This allows sorting by IP address by numeric sort on the `${IPnum}` column.
 
 * Fixed Bugs:
 

--- a/arp-scan.1.dist
+++ b/arp-scan.1.dist
@@ -5,7 +5,7 @@
 .\" are permitted in any medium without royalty provided the copyright
 .\" notice and this notice are preserved.
 .\"
-.TH ARP-SCAN 1 "January 14, 2023"
+.TH ARP-SCAN 1 "March 09, 2023"
 .\" Please adjust this date whenever revising the man page.
 .SH NAME
 arp-scan \- Send ARP requests to target hosts and display responses
@@ -264,6 +264,7 @@ VLAN	802.1Q VLAN ID if present
 Proto	ARP protocol if not 0x0800
 DUP	Packet number for duplicate packets (>1)
 RTT	Round trip time if \fB--rtt\fP option given
+IPnum	Host IPv4 address as a 32-bit integer
 .TE
 .sp
 Only the \fI${ip}\fP and \fI${mac}\fP fields are available if the

--- a/arp-scan.c
+++ b/arp-scan.c
@@ -684,13 +684,14 @@ display_packet(host_entry *he, arp_ether_ipv4 *arpei,
    static field fields[NUMFIELDS] = {
       {"IP",NULL},     {"Name",NULL},    {"MAC",NULL},     {"HdrMAC",NULL},
       {"Vendor",NULL}, {"Padding",NULL}, {"Framing",NULL}, {"VLAN",NULL},
-      {"Proto",NULL},  {"DUP",NULL},     {"RTT",NULL}
+      {"Proto",NULL},  {"DUP",NULL},     {"RTT",NULL},     {"IPnum",NULL},
    };
    static const id_name_map fields_map[] = {
       {0, "IP"},      {1, "Name"},   {2, "MAC"},
       {3, "HdrMAC"},  {4, "Vendor"}, {5, "Padding"},
       {6, "Framing"}, {7, "VLAN"},   {8, "Proto"},
-      {9, "DUP"},     {10, "RTT"},   {-1, NULL} /* -1 marks end of list */
+      {9, "DUP"},     {10, "RTT"},   {11, "IPnum"},
+      {-1, NULL} /* -1 marks end of list */
    };
    char *msg;
    char *cp;
@@ -840,6 +841,10 @@ display_packet(host_entry *he, arp_ether_ipv4 *arpei,
          fields[10].value=make_message("%lu.%03lu", rtt_us/1000, rtt_us%1000);
       }
    } /* End if (!quiet_flag) */
+   /*
+    * IPnum field, always present
+    */
+   fields[11].value=make_message("%lu", ntohl(he->addr.s_addr));
    /*
     * Output fields.
     */
@@ -1238,6 +1243,7 @@ usage(void) {
    printf("\t\t\tProto\tARP protocol if not 0x0800\n");
    printf("\t\t\tDUP\tPacket number for duplicate packets (>1)\n");
    printf("\t\t\tRTT\tRound trip time if --rtt option given\n");
+   printf("\t\t\tIPnum\tHost IPv4 address as a 32-bit integer\n");
    printf("\t\t\t\n");
    printf("\t\t\tOnly the \"ip\" and \"mac\" fields are available if the\n");
    printf("\t\t\t--quiet option is specified.\n");

--- a/arp-scan.h
+++ b/arp-scan.h
@@ -173,7 +173,7 @@
 #define DEFAULT_RETRY_SEND 20		/* Default no. of send packet retries */
 #define DEFAULT_RETRY_SEND_INTERVAL 5000  /* Default interval between send
                                         * packet retries in microseconds */
-#define NUMFIELDS 11			/* Number of output fields */
+#define NUMFIELDS 12			/* Number of output fields */
 
 /* Structures */
 


### PR DESCRIPTION
Add `${IPnum}` output field to display the host IPv4 address as a 32-bit integer.

Issue ref: #156