### PR TITLE
Add example of field width usage to man page

### DIFF
--- a/arp-scan.1.dist
+++ b/arp-scan.1.dist
@@ -284,7 +284,14 @@ L L .
 You should enclose the \fB--format\fP argument in 'single
 quotes' to protect special characters from the shell.
 .sp
-Example: --format='${ip}\\t${mac}\\t${vendor}'
+Examples:
+.sp
+.TS
+L .
+--format='${ip}\\t${mac}\\t${vendor}'\n
+--resolve --format='${ip}\\t${mac}\\t${name;20}\\t${vendor}'
+.TE
+.TP
 .SS "Host List Randomisation"
 .TP
 .BR --random " or " -R


### PR DESCRIPTION
Old:
```
              You should enclose the --format argument in 'single quotes' to protect special characters from the shell.

              Example: --format='${ip}\t${mac}\t${vendor}'
```

New:
```
              You should enclose the --format argument in 'single quotes' to protect special characters from the shell.

              Examples:

              --format='${ip}\t${mac}\t${vendor}'
              --resolve --format='${ip}\t${mac}\t${name;20}\t${vendor}'
```