### PR TITLE
Flush stdout buffer after displaying each responding host

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -6,6 +6,11 @@
 	  arp-scan currently uses C89 but use of C99 features is planned for
 	  the next release.
 
+	* arp-scan.c: flush stdout output buffer after displaying each response.
+	  This ensures that responding hosts are seen immediately when reading
+	  from a pipeline rather than having to wait until the output buffer
+	  is filled.
+
 2023-10-22 Roy Hills <royhills@hotmail.com>
 
 	* TODO: Moved all valid items from TODO to github issue with the

--- a/arp-scan.c
+++ b/arp-scan.c
@@ -956,11 +956,14 @@ display_packet(host_entry *he, arp_ether_ipv4 *arpei,
       }
    }
    /*
-    * Display the message on stdout.
+    * Display the message on stdout and flush output buffer.
     */
    printf("%s\n", msg);
+   fflush(stdout);
+   /*
+    * Free the message and any field values.
+    */
    free(msg);
-
    for (i=0; i<NUMFIELDS; i++)
       if (fields[i].value) {
          free(fields[i].value);


### PR DESCRIPTION
Flush the stdout buffer after displaying each responding hosts. This ensures that responding hosts are available immediately when reading `arp-scan` output from a pipeline.
