### PR TITLE
C99 header and autoconf changes

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -20,6 +20,12 @@
 	  mappings (4575 IAB + 5121 MAM + 34879 OUI + 5791 OUI36).
 	  https://github.com/royhills/arp-scan/pull/174
 
+	* configure.ac, arp-scan.h: include <stdint.h> unconditionally and
+	  remove autoconf checks for fixed width integer types now we can
+	  assume C99 support. Removed include <sys/types.h> because <unistd.h>
+	  makes it unnecessary.
+	  https://github.com/royhills/arp-scan/pull/175
+
 2023-10-22 Roy Hills <royhills@hotmail.com>
 
 	* TODO: Moved all valid items from TODO to github issue with the

--- a/arp-scan.h
+++ b/arp-scan.h
@@ -36,17 +36,8 @@
 #include <errno.h>
 #include <limits.h>
 #include <assert.h>
-
-#include <sys/types.h>
-
-/* Integer types (C99) */
-#ifdef HAVE_INTTYPES_H
-#include <inttypes.h>
-#else
-#ifdef HAVE_STDINT_H
+/* C99 standard headers */
 #include <stdint.h>
-#endif
-#endif
 
 #ifdef HAVE_UNISTD_H
 #include <unistd.h>

--- a/configure.ac
+++ b/configure.ac
@@ -92,11 +92,6 @@ AC_CHECK_HEADERS([getopt.h pcap.h sys/ioctl.h ifaddrs.h])
 # Checks for typedefs, structures, and compiler characteristics.
 AC_TYPE_SIZE_T
 
-AC_TYPE_UINT8_T
-AC_TYPE_UINT16_T
-AC_TYPE_UINT32_T
-AC_TYPE_UINT64_T
-
 # Checks for library functions.
 # All of these are defined by POSIX
 AC_CHECK_FUNCS([malloc gethostbyname gettimeofday inet_ntoa memset select socket strerror])


### PR DESCRIPTION
Simplification of autoconf configuration and C headers that are possible because we can assume that the C compiler supports C99 (PR https://github.com/royhills/arp-scan/pull/171):

* Include C99 standard header file `stdint.h` unconditionally.
* Remove autoconf checks for `AC_TYPE_UINT{8,16,32,64}_T`.


