### PR TITLE
Use stdout instead of stderr for "Target list from interface" message

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,9 @@
+2024-01-10 Roy Hills <royhills@hotmail.com>
+
+	* arp-scan.c: Use printf() instead of warn_msg() for the "Target list
+	  from interface" message so the output is sent to stdout instead of
+	  stderr.
+
 2024-01-04 Roy Hills <royhills@hotmail.com>
 
 	* configure.ac, README.md: Require C compiler with C99 language support.

--- a/arp-scan.c
+++ b/arp-scan.c
@@ -428,8 +428,8 @@ main(int argc, char *argv[]) {
       c_netmask = make_message("%s", cp);
       snprintf(localnet_descr, 32, "%s:%s", c_network, c_netmask);
       if (!plain_flag) {
-         warn_msg("Target list from interface: network %s netmask %s",
-                  c_network, c_netmask);
+         printf("Target list from interface: network %s netmask %s\n",
+                 c_network, c_netmask);
       }
       free(c_network);
       free(c_netmask);


### PR DESCRIPTION
We should only use stderr for error or debug messages, not for normal messages. So change warn_msg() to printf() for the "Target list from interface" message.