### PR TITLE
Remove unused variable "iterations” from find_host().

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,9 @@
+2025-03-07 Roy Hills <royhills@hotmail.com>
+
+	* arp-scan.c: Removed unused variable _iterations_ from find_host(). Detected by Apple Clang version 16.0.0 (clang-1600.0.26.6).
+
+	* NEWS: Updated to 2025-02-12.
+
 2025-02-12 Roy Hills <royhills@hotmail.com>
 
 	* arp-scan.c, arp-scan.h, arp-scan.1.dist: Add --exclude-broadcast option

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,6 +1,7 @@
 2025-03-07 Roy Hills <royhills@hotmail.com>
 
 	* arp-scan.c: Removed unused variable _iterations_ from find_host(). Detected by Apple Clang version 16.0.0 (clang-1600.0.26.6).
+	  https://github.com/royhills/arp-scan/pull/200
 
 	* NEWS: Updated to 2025-02-12.
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,7 @@
   - OpenBSD: Call `pledge(2)` to enter restricted service mode once initial setup is complete. `arp-scan --version` output includes `Built with
     OpenBSD pledge(2) support` if applicable.
   - New `${IPnum}` field name for the `--format` option which displays the host IP address as a 32-bit unsigned integer. This allows sorting by IP address by numeric sort on the `${IPnum}` column.
+  - New _--exclude-broadcast_ option to select whether generated IP ranges include the network and broadcast address.
 
 * Fixed Bugs:
 
@@ -24,6 +25,9 @@
   - Self-test code coverage increased to 91.2% (see [code-coverage.yml](/.github/workflows/code-coverage.yml) for details of the code coverage tests).
   - `CONTRIBUTING.md` and `SECURITY.md` files added.
   - Change message about interface network and mask used for --localnet, and don't require --verbose to display it.
+  - Source tree tidy-up: move test data files into separate _testdata_ directory; moved local autoconf macros to seperate files under _m4_ (requires autoconf >= 2.70 to build - v1.10.0 required autoconf >= 2.69).
+  - Require a compiler with C99 support.
+  - Change the HTTP user agent string used by the _get_oui_ script to mimic Chrome on Windows 10/x64 because the IEEE site rejects requests with the default libwww-perl user agent.
   - Various minor improvements to the code and documentation.
 
 # 2022-12-10 arp-scan 1.10.0 (git tag 1.10.0)

--- a/NEWS.md
+++ b/NEWS.md
@@ -28,6 +28,7 @@
   - Source tree tidy-up: move test data files into separate _testdata_ directory; moved local autoconf macros to seperate files under _m4_ (requires autoconf >= 2.70 to build - v1.10.0 required autoconf >= 2.69).
   - Require a compiler with C99 support.
   - Change the HTTP user agent string used by the _get_oui_ script to mimic Chrome on Windows 10/x64 because the IEEE site rejects requests with the default libwww-perl user agent.
+  - Removed "Ununsed variable" reported by Clang 16.0.
   - Various minor improvements to the code and documentation.
 
 # 2022-12-10 arp-scan 1.10.0 (git tag 1.10.0)

--- a/arp-scan.c
+++ b/arp-scan.c
@@ -1745,7 +1745,6 @@ host_entry *
 find_host(host_entry **he, struct in_addr *addr) {
    host_entry **p;
    int found = 0;
-   unsigned iterations = 0; /* Used for debugging */
 
    assert (*he != NULL);
    /*
@@ -1754,7 +1753,6 @@ find_host(host_entry **he, struct in_addr *addr) {
    p = he;
 
    do {
-      iterations++;
       if ((*p)->addr.s_addr == addr->s_addr) {
          found = 1;
       } else {


### PR DESCRIPTION
Remove unused variable “iterations” from find_host(). Updated NEWS file.

Detected by Apple Clang version 16.0.0 (clang-1600.0.26.6).

This unused var was not detected by gcc 12.2 on Debian bookworm.
